### PR TITLE
Unify logging format and add telemetry instrumentation

### DIFF
--- a/admin_app/schedule_parser.py
+++ b/admin_app/schedule_parser.py
@@ -22,8 +22,6 @@ from sheets_api import SheetsAPI, SheetsAPIError  # централизованн
 from config import GOOGLE_SHEET_NAME  # только для сообщений
 
 logger = logging.getLogger(__name__)
-if not logger.hasHandlers():
-    logging.basicConfig(level=logging.INFO)
 
 # Возможные названия листа с графиком (приоритет по порядку)
 CANDIDATE_SCHEDULE_TITLES = ["ShiftCalendar", "Schedule", "График"]

--- a/auto_sync.py
+++ b/auto_sync.py
@@ -9,17 +9,27 @@ from typing import Dict, List, Optional
 import socket
 from time import monotonic
 
+from logging_setup import setup_logging
+
 PROJECT_ROOT = Path(__file__).parent
 sys.path.insert(0, str(PROJECT_ROOT))
+
+logger = logging.getLogger(__name__)
 
 try:
     from PyQt5.QtCore import QObject, pyqtSignal
 except ImportError:
-    logging.warning("PyQt5 не найден. Сигналы GUI не будут работать. Запуск в режиме CLI.")
-    class QObject: pass
-    class pyqtSignal:
-        def __init__(self): pass
-        def emit(self, *args, **kwargs): pass
+    logger.warning("PyQt5 не найден. Сигналы GUI не будут работать. Запуск в режиме CLI.")
+
+    class QObject:  # type: ignore
+        pass
+
+    class pyqtSignal:  # type: ignore
+        def __init__(self):
+            pass
+
+        def emit(self, *args, **kwargs):
+            pass
 
 try:
     from config import (
@@ -37,7 +47,7 @@ try:
     from sync.network import is_internet_available
     from sync.session_inspector import SessionInspector
 except ImportError as e:
-    logging.error(f"Ошибка импорта модулей: {e}")
+    logger.error("Ошибка импорта модулей: %s", e)
     raise
 
 # Пулинг персональных правила перенесён в notifications.engine; безопасный импорт с фолбэком
@@ -48,8 +58,6 @@ except Exception:
         return
 
 # Персональные правила теперь обрабатываются через движок уведомлений, прямой импорт не нужен.
-
-logger = logging.getLogger(__name__)
 
 PING_PORT = 43333
 PING_TIMEOUT = 3600  # 1 час
@@ -484,15 +492,8 @@ class SyncManager(QObject):
             return self._stats.copy()
 
 def main():
-    logging.basicConfig(
-        level=logging.INFO,
-        format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
-        handlers=[
-            logging.StreamHandler(sys.stdout),
-            logging.FileHandler(PROJECT_ROOT / "logs" / "sync_service.log", encoding='utf-8')
-        ]
-    )
-    
+    setup_logging(app_name="sync_service", log_dir=PROJECT_ROOT / "logs", force_console=True)
+
     logger.info("=== ЗАПУСК СЕРВИСА СИНХРОНИЗАЦИИ В КОНСОЛЬНОМ РЕЖИМЕ ===")
     
     manager = SyncManager(background_mode=True)

--- a/build_admin.py
+++ b/build_admin.py
@@ -1,32 +1,28 @@
 # build_admin.py
-import os
-import sys
 import logging
 import shutil
+import sys
 from pathlib import Path
+
 from PyInstaller.__main__ import run
 
-logging.basicConfig(
-    level=logging.INFO,
-    format='%(asctime)s - %(levelname)s - %(message)s',
-    handlers=[
-        logging.FileHandler('build_admin.log', mode='w', encoding='utf-8'),
-        logging.StreamHandler()
-    ]
-)
+from logging_setup import setup_logging
+
+
 logger = logging.getLogger(__name__)
 
-def main():
+
+def main() -> None:
     try:
         logger.info("🚀 Сборка админки...")
         app_name = "WorkTimeTracker_Admin"
-        main_script = "admin_app/main_admin.py" # Путь от корня
-        icon_file = "user_app/sberhealf.ico" # Используем ту же иконку
+        main_script = "admin_app/main_admin.py"  # Путь от корня
+        icon_file = "user_app/sberhealf.ico"  # Используем ту же иконку
 
         for dir_name in ['dist', 'build']:
             if Path(dir_name).exists():
                 shutil.rmtree(dir_name)
-                logger.info(f"🧹 Очищена директория: {dir_name}")
+                logger.info("🧹 Очищена директория: %s", dir_name)
 
         options = [
             main_script,
@@ -37,7 +33,7 @@ def main():
             '--noconfirm',
             '--log-level=WARN',
             f'--icon={icon_file}' if Path(icon_file).exists() else None,
-            '--paths=.', # Ключевая строка
+            '--paths=.',  # Ключевая строка
             '--add-data=secret_creds.zip;.',
             '--add-data=config.py;.',
             '--add-data=user_app/sberhealf.png;user_app',
@@ -48,18 +44,20 @@ def main():
 
         options = [opt for opt in options if opt is not None]
 
-        logger.info(f"⚙️  Запуск: {' '.join(options)}")
+        logger.info("⚙️  Запуск: %s", ' '.join(options))
         run(options)
 
         exe_path = Path('dist') / app_name / f"{app_name}.exe"
         if exe_path.exists():
-            logger.info(f"✅ Успех! {exe_path}")
+            logger.info("✅ Успех! %s", exe_path)
         else:
             raise RuntimeError("Сборка прошла, но exe не найден.")
 
-    except Exception as e:
-        logger.critical(f"❌ Ошибка: {e}", exc_info=True)
+    except Exception as exc:
+        logger.critical("❌ Ошибка: %s", exc, exc_info=exc)
         sys.exit(1)
 
+
 if __name__ == "__main__":
+    setup_logging(app_name="build_admin", log_dir=Path.cwd(), force_console=True)
     main()

--- a/build_user.py
+++ b/build_user.py
@@ -6,14 +6,7 @@ import shutil
 from pathlib import Path
 from PyInstaller.__main__ import run
 
-logging.basicConfig(
-    level=logging.INFO,
-    format='%(asctime)s - %(levelname)s - %(message)s',
-    handlers=[
-        logging.FileHandler('build_user.log', mode='w', encoding='utf-8'),
-        logging.StreamHandler()
-    ]
-)
+from logging_setup import setup_logging
 logger = logging.getLogger(__name__)
 
 def main():
@@ -86,4 +79,5 @@ def main():
         sys.exit(1)
 
 if __name__ == "__main__":
+    setup_logging(app_name="build_user", log_dir=Path.cwd(), force_console=True)
     main()

--- a/bundle_project.py
+++ b/bundle_project.py
@@ -22,13 +22,19 @@ from __future__ import annotations
 
 import argparse
 import hashlib
+import logging
 import mimetypes
 import os
 import sqlite3
 import sys
 import time
 from pathlib import Path
-from typing import Iterable, List, Dict, Optional, Tuple
+from typing import Dict, Iterable, List, Optional, Tuple
+
+from logging_setup import setup_logging
+
+
+logger = logging.getLogger(__name__)
 
 # -----------------------------------
 # 1) Настройки для дерева и бандла
@@ -402,6 +408,7 @@ def introspect_gsheets(sample_limit: int = 3) -> str:
 # -----------------------------------
 
 def main():
+    setup_logging(app_name="wtt-bundle-project", force_console=True)
     ap = argparse.ArgumentParser(description="Собрать отчёт по проекту (дерево, бандл, SQLite, Google Sheets).")
     ap.add_argument("-r", "--root", type=str, default=".", help="Корень проекта (default .)")
     ap.add_argument("-o", "--output", type=str, default="project_report.txt", help="Путь к выходному TXT.")
@@ -460,7 +467,10 @@ def main():
                     continue
             files.sort(key=lambda x: str(x).lower())
         except Exception as e:
-            print(f"[WARN] git-only режим не удался: {e}. Переход к файловому обходу.", file=sys.stderr)
+            logger.warning(
+                "git-only режим не удался. Переход к файловому обходу.",
+                exc_info=e,
+            )
             files = collect_files(root, include_exts, exclude_dirs, args.max_bytes)
     else:
         files = collect_files(root, include_exts, exclude_dirs, args.max_bytes)
@@ -510,7 +520,7 @@ def main():
         # Бандл исходников
         write_bundle(out, root, files)
 
-    print(f"✓ Готово: {out_path}")
+    logger.info("Готово: %s", out_path)
 
 if __name__ == "__main__":
     main()

--- a/collect_diagnostics.py
+++ b/collect_diagnostics.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import contextlib
 import hashlib
+import logging
 import io
 import json
 import os
@@ -20,6 +21,9 @@ from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 from typing import Iterable, Iterator, Optional
+
+
+logger = logging.getLogger(__name__)
 
 # ---------- Аргументы CLI ----------
 
@@ -404,6 +408,9 @@ def dump_env(root: Path, redact_secrets: bool) -> str:
 # ---------- Основная логика ----------
 
 def main() -> int:
+    from logging_setup import setup_logging
+
+    setup_logging(app_name="wtt-collect-diagnostics", force_console=True)
     args = parse_args()
     project_root = args.project_root.resolve()
     exclude_dirs = set(d.strip() for d in args.exclude_dirs.split(","))
@@ -480,7 +487,7 @@ def main() -> int:
     # запись
     args.output.parent.mkdir(parents=True, exist_ok=True)
     args.output.write_text(buf.getvalue(), encoding="utf-8")
-    print(f"Report written to: {args.output}")
+    logger.info("Report written to: %s", args.output)
     return 0
 
 if __name__ == "__main__":

--- a/config.py
+++ b/config.py
@@ -1,4 +1,5 @@
 # config.py
+import logging
 import os
 import sys
 import platform
@@ -9,11 +10,15 @@ import atexit
 
 # ==================== Загрузка переменных окружения из .env ====================
 from dotenv import load_dotenv
+
 load_dotenv()
 
 # ==================== Импорт для работы с зашифрованным credentials ====================
 import pyzipper
 import tempfile
+
+
+logger = logging.getLogger(__name__)
 
 # ==================== Базовые настройки ====================
 if getattr(sys, 'frozen', False):
@@ -366,10 +371,10 @@ def normalize_group_name(name: str) -> str:
 # ==================== Инициализация конфигурации ====================
 try:
     validate_config()
-    print("✓ Конфигурация успешно проверена")
-    print(f"✓ Стратегия повторных попыток: {SYNC_RETRY_STRATEGY}")
+    logger.info("Конфигурация успешно проверена")
+    logger.info("Стратегия повторных попыток: %s", SYNC_RETRY_STRATEGY)
 except Exception as e:
-    print(f"✗ Ошибка конфигурации: {e}")
+    logger.error("Ошибка конфигурации", exc_info=e)
     raise
 
 # ==================== Утилиты для PyInstaller ====================
@@ -383,50 +388,52 @@ def get_resource_path(relative_path: str) -> str:
 
 # ==================== Константы для тестирования ====================
 if __name__ == "__main__":
-    print(f"BASE_DIR: {BASE_DIR}")
-    print(f"LOG_DIR: {LOG_DIR}")
-    print(f"CREDENTIALS_ZIP: {CREDENTIALS_ZIP}")
-    print(f"SYNC_RETRY_STRATEGY: {SYNC_RETRY_STRATEGY}")
-    print(f"Максимальная задержка: {max(SYNC_RETRY_STRATEGY)} секунд ({max(SYNC_RETRY_STRATEGY)/60} минут)")
-    
-    # Тестируем ленивую загрузку credentials
+    from logging_setup import setup_logging
+
+    setup_logging(app_name="wtt-config", force_console=True)
+    logger.info("BASE_DIR: %s", BASE_DIR)
+    logger.info("LOG_DIR: %s", LOG_DIR)
+    logger.info("CREDENTIALS_ZIP: %s", CREDENTIALS_ZIP)
+    logger.info("SYNC_RETRY_STRATEGY: %s", SYNC_RETRY_STRATEGY)
+    logger.info(
+        "Максимальная задержка: %s секунд (%.2f минут)",
+        max(SYNC_RETRY_STRATEGY),
+        max(SYNC_RETRY_STRATEGY) / 60,
+    )
+
     try:
         with credentials_path() as creds:
-            print(f"✓ Credentials file: {creds}")
-            print(f"✓ File exists: {creds.exists()}")
+            logger.info("Credentials file: %s", creds)
+            logger.info("Credentials file exists: %s", creds.exists())
     except Exception as e:
-        print(f"✗ Error accessing credentials: {e}")
-    
-    # Тестируем новые настройки правил
-    print(f"PERSONAL_RULES_ENABLED: {PERSONAL_RULES_ENABLED}")
-    print(f"PERSONAL_WINDOW_MIN: {PERSONAL_WINDOW_MIN}")
-    print(f"PERSONAL_STATUS_LIMIT_PER_WINDOW: {PERSONAL_STATUS_LIMIT_PER_WINDOW}")
-    print(f"SERVICE_ALERTS_ENABLED: {SERVICE_ALERTS_ENABLED}")
-    print(f"SERVICE_ALERT_MIN_SECONDS: {SERVICE_ALERT_MIN_SECONDS}")
-    
-    # Тестируем новые константы для логина
-    print(f"ALLOW_SELF_SIGNUP: {ALLOW_SELF_SIGNUP}")
-    print(f"DEFAULT_USER_ROLE: {DEFAULT_USER_ROLE}")
-    print(f"DEFAULT_SHIFT_HOURS: {DEFAULT_SHIFT_HOURS}")
-    
-    # Тестируем новую карту листов WorkLog
-    print(f"WORKLOG_SHEETS_MAP: {WORKLOG_SHEETS_MAP}")
-    print(f"DEFAULT_WORKLOG_SHEET: {DEFAULT_WORKLOG_SHEET}")
-    print(f"WORKLOG_SHEET (обратная совместимость): {WORKLOG_SHEET}")
-    
-    # Тестируем новые параметры групповых вкладок
-    print(f"WORKLOG_SHEET_PREFIX: {WORKLOG_SHEET_PREFIX}")
-    print(f"WORKLOG_RESOLUTION: {WORKLOG_RESOLUTION}")
-    print(f"AUTOCREATE_WORKLOG_SHEET: {AUTOCREATE_WORKLOG_SHEET}")
-    print(f"DEFAULT_WORKLOG_GROUP: {DEFAULT_WORKLOG_GROUP}")
-    
-    # Тестируем новую групповую схему WorkLog
-    print(f"WORKLOG_GROUP_PREFIX: {WORKLOG_GROUP_PREFIX}")
-    print(f"DEFAULT_WORKLOG_GROUP: {DEFAULT_WORKLOG_GROUP}")
-    print(f"WORKLOG_HEADERS: {WORKLOG_HEADERS}")
-    
-    # Тестируем функцию нормализации
+        logger.error("Error accessing credentials", exc_info=e)
+
+    logger.info("PERSONAL_RULES_ENABLED: %s", PERSONAL_RULES_ENABLED)
+    logger.info("PERSONAL_WINDOW_MIN: %s", PERSONAL_WINDOW_MIN)
+    logger.info(
+        "PERSONAL_STATUS_LIMIT_PER_WINDOW: %s",
+        PERSONAL_STATUS_LIMIT_PER_WINDOW,
+    )
+    logger.info("SERVICE_ALERTS_ENABLED: %s", SERVICE_ALERTS_ENABLED)
+    logger.info("SERVICE_ALERT_MIN_SECONDS: %s", SERVICE_ALERT_MIN_SECONDS)
+
+    logger.info("ALLOW_SELF_SIGNUP: %s", ALLOW_SELF_SIGNUP)
+    logger.info("DEFAULT_USER_ROLE: %s", DEFAULT_USER_ROLE)
+    logger.info("DEFAULT_SHIFT_HOURS: %s", DEFAULT_SHIFT_HOURS)
+
+    logger.info("WORKLOG_SHEETS_MAP: %s", WORKLOG_SHEETS_MAP)
+    logger.info("DEFAULT_WORKLOG_SHEET: %s", DEFAULT_WORKLOG_SHEET)
+    logger.info("WORKLOG_SHEET (обратная совместимость): %s", WORKLOG_SHEET)
+
+    logger.info("WORKLOG_SHEET_PREFIX: %s", WORKLOG_SHEET_PREFIX)
+    logger.info("WORKLOG_RESOLUTION: %s", WORKLOG_RESOLUTION)
+    logger.info("AUTOCREATE_WORKLOG_SHEET: %s", AUTOCREATE_WORKLOG_SHEET)
+    logger.info("DEFAULT_WORKLOG_GROUP: %s", DEFAULT_WORKLOG_GROUP)
+
+    logger.info("WORKLOG_GROUP_PREFIX: %s", WORKLOG_GROUP_PREFIX)
+    logger.info("WORKLOG_HEADERS: %s", WORKLOG_HEADERS)
+
     test_names = ["  Входящие  ", "Почта", "  ", None]
     for name in test_names:
         normalized = normalize_group_name(name)
-        print(f"normalize_group_name('{name}') = '{normalized}'")
+        logger.info("normalize_group_name('%s') -> '%s'", name, normalized)

--- a/logging_setup.py
+++ b/logging_setup.py
@@ -1,13 +1,18 @@
 # logging_setup.py
 from __future__ import annotations
 
+import contextlib
+import contextvars
 import logging
 import os
 import re
 import sys
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
-from typing import Optional, Union
+from typing import Iterator, Optional, Union
+from uuid import uuid4
+
+from datetime import datetime, timezone
 
 # Внутренние флаги, чтобы не плодить хендлеры
 _LOGGING_INITIALIZED = False
@@ -27,6 +32,104 @@ class PIIFilter(logging.Filter):
         if isinstance(record.msg, str):
             record.msg = _mask_pii(record.msg)
         return True
+
+
+# --------------------------- correlation context -----------------------------
+_request_id_var: contextvars.ContextVar[str] = contextvars.ContextVar(
+    "wtt_request_id", default="-"
+)
+_session_id_var: contextvars.ContextVar[str] = contextvars.ContextVar(
+    "wtt_session_id", default="-"
+)
+
+
+def _clean_value(value: Optional[str]) -> str:
+    if value is None:
+        return "-"
+    value = str(value).strip()
+    return value or "-"
+
+
+def set_request_id(request_id: Optional[str]) -> None:
+    """Persist request correlation identifier in the current context."""
+
+    _request_id_var.set(_clean_value(request_id))
+
+
+def get_request_id() -> str:
+    """Return request identifier stored in the current context."""
+
+    return _clean_value(_request_id_var.get())
+
+
+def set_session_id(session_id: Optional[str]) -> None:
+    """Persist session identifier in the current context."""
+
+    _session_id_var.set(_clean_value(session_id))
+
+
+def get_session_id() -> str:
+    """Return session identifier stored in the current context."""
+
+    return _clean_value(_session_id_var.get())
+
+
+def new_request_id() -> str:
+    """Generate a new opaque correlation identifier."""
+
+    return uuid4().hex
+
+
+@contextlib.contextmanager
+def correlation_context(
+    *, request_id: Optional[str] = None, session_id: Optional[str] = None
+) -> Iterator[None]:
+    """
+    Context manager to temporarily override correlation identifiers.
+
+    Examples
+    --------
+    >>> with correlation_context(request_id="abc", session_id="sid"):
+    ...     logger.info("Will carry correlation fields")
+    """
+
+    tokens: list[tuple[contextvars.ContextVar[str], contextvars.Token[str]]] = []
+    try:
+        if request_id is not None:
+            tokens.append((_request_id_var, _request_id_var.set(_clean_value(request_id))))
+        if session_id is not None:
+            tokens.append((_session_id_var, _session_id_var.set(_clean_value(session_id))))
+        yield
+    finally:
+        for var, token in reversed(tokens):
+            var.reset(token)
+
+
+class CorrelationFilter(logging.Filter):
+    """Ensure correlation identifiers are always present on log records."""
+
+    def filter(self, record: logging.LogRecord) -> bool:  # pragma: no cover - trivial
+        if not hasattr(record, "request_id"):
+            record.request_id = get_request_id()
+        else:
+            record.request_id = _clean_value(record.request_id)
+        if not hasattr(record, "session_id"):
+            record.session_id = get_session_id()
+        else:
+            record.session_id = _clean_value(record.session_id)
+        return True
+
+
+class ISOFormatter(logging.Formatter):
+    """Formatter producing ISO-8601 timestamps."""
+
+    def formatTime(
+        self, record: logging.LogRecord, datefmt: Optional[str] = None
+    ) -> str:
+        dt = datetime.fromtimestamp(record.created, tz=timezone.utc)
+        if datefmt:
+            return dt.strftime(datefmt)
+        return dt.isoformat(timespec="milliseconds")
 
 
 # --------------------------- helpers / internals ------------------------------
@@ -121,8 +224,8 @@ def _setup_logging_impl(
 
         _LOGGING_INITIALIZED = True
 
-    fmt = logging.Formatter(
-        "%(asctime)s - %(name)s - %(levelname)s - %(message)s", datefmt="%Y-%m-%d %H:%M:%S"
+    fmt = ISOFormatter(
+        "%(asctime)s %(levelname)s %(name)s request_id=%(request_id)s session_id=%(session_id)s - %(message)s"
     )
 
     # Файловый хендлер с ротацией
@@ -132,6 +235,7 @@ def _setup_logging_impl(
     fh.setLevel(level)
     fh.setFormatter(fmt)
     fh.addFilter(PIIFilter())
+    fh.addFilter(CorrelationFilter())
 
     _configure_root_logger(level, fh)
 
@@ -141,6 +245,7 @@ def _setup_logging_impl(
         ch.setLevel(level)
         ch.setFormatter(fmt)
         ch.addFilter(PIIFilter())
+        ch.addFilter(CorrelationFilter())
         logging.getLogger().addHandler(ch)
 
     logging.getLogger(__name__).info(
@@ -212,4 +317,14 @@ def setup_logging_compat(*args, **kwargs) -> Path:
     return setup_logging(app_name=str(name), log_dir=log_dir, level=lvl)
 
 
-__all__ = ["setup_logging", "setup_logging_compat", "init_app_log_path"]
+__all__ = [
+    "setup_logging",
+    "setup_logging_compat",
+    "init_app_log_path",
+    "set_request_id",
+    "get_request_id",
+    "set_session_id",
+    "get_session_id",
+    "new_request_id",
+    "correlation_context",
+]

--- a/map_project.py
+++ b/map_project.py
@@ -1,4 +1,10 @@
+import logging
 import os
+
+from logging_setup import setup_logging
+
+
+logger = logging.getLogger(__name__)
 
 EXCLUDE = {'.venv', '__pycache__', '.git', '.idea', 'dist', 'build'}
 def tree(dir_path, prefix=''):
@@ -7,9 +13,11 @@ def tree(dir_path, prefix=''):
     for i, name in enumerate(entries):
         path = os.path.join(dir_path, name)
         connector = '└── ' if i == len(entries) - 1 else '├── '
-        print(prefix + connector + name)
+        logger.info("%s", prefix + connector + name)
         if os.path.isdir(path):
             extension = '    ' if i == len(entries) - 1 else '│   '
             tree(path, prefix + extension)
 
-tree('.')
+if __name__ == "__main__":
+    setup_logging(app_name="wtt-map-project", force_console=True)
+    tree('.')

--- a/sheets_api.py
+++ b/sheets_api.py
@@ -16,6 +16,9 @@ import threading
 from zoneinfo import ZoneInfo  # stdlib (Python 3.9+)
 import re
 from difflib import get_close_matches
+from types import MethodType
+
+from telemetry import record_network_call
 
 logger = logging.getLogger("sheets_api")  # никаких handlers здесь — конфиг только в приложении
 
@@ -119,6 +122,20 @@ class SheetsAPI:
                 details=str(e)
             )
 
+    def _instrument_session(
+        self, session: AuthorizedSession, prefix: str
+    ) -> AuthorizedSession:
+        original_request = session.request
+
+        def wrapped_request(_self_session: AuthorizedSession, method: str, url: str, *args, **kwargs):
+            endpoint = url.split("?", 1)[0]
+            metric_name = f"{prefix}.{method.lower()}:{endpoint}"
+            with record_network_call(metric_name):
+                return original_request(method, url, *args, **kwargs)
+
+        session.request = MethodType(wrapped_request, session)
+        return session
+
     # ---------- low-level client/bootstrap ----------
 
     def _init_client(self, max_retries: int = 3) -> None:
@@ -138,13 +155,13 @@ class SheetsAPI:
                 ]
                 credentials = Credentials.from_service_account_file(str(self.credentials_path), scopes=scopes)
                 self.client = gspread.client.Client(auth=credentials)
-                # gspread >=5
-                self.client.session = AuthorizedSession(credentials)
+                client_session = AuthorizedSession(credentials)
+                self.client.session = self._instrument_session(client_session, "gspread")
                 # На некоторых версиях http_client может отсутствовать — оставляем, как было у тебя
                 if hasattr(self.client, "http_client") and hasattr(self.client.http_client, "timeout"):
                     self.client.http_client.timeout = 30
 
-                self._session = AuthorizedSession(credentials)
+                self._session = self._instrument_session(AuthorizedSession(credentials), "google")
                 # У объекта AuthorizedSession нет атрибута timeout во всех версиях,
                 # но если есть — выставим.
                 try:
@@ -181,7 +198,9 @@ class SheetsAPI:
             logger.error(f"API connection test failed: {e}")
             try:
                 import urllib.request
-                urllib.request.urlopen('https://www.google.com', timeout=5)
+
+                with record_network_call("network.google_ping"):
+                    urllib.request.urlopen('https://www.google.com', timeout=5)
                 logger.debug("Internet connection is available")
             except Exception:
                 logger.error("No internet connection detected")

--- a/sync/network.py
+++ b/sync/network.py
@@ -1,25 +1,31 @@
 # sync/network.py
-import urllib.request
-import socket
+from __future__ import annotations
+
 import logging
+import socket
+import urllib.request
+
+from telemetry import record_network_call
+
 
 logger = logging.getLogger(__name__)
 
+
 def is_internet_available(timeout: int = 3) -> bool:
     """Проверить доступность интернета."""
+
     try:
-        logger.debug("Проверка доступности интернета...")
-        # Используем google.com или любой стабильный сайт
-        response = urllib.request.urlopen("https://www.google.com", timeout=timeout)
-        if response.status == 200:
-            logger.debug("Интернет доступен")
-            return True
-        else:
-            logger.warning(f"Ответ сервера Google: {response.status}")
+        with record_network_call("network.internet_check"):
+            logger.debug("Проверка доступности интернета...")
+            response = urllib.request.urlopen("https://www.google.com", timeout=timeout)
+            if response.status == 200:
+                logger.debug("Интернет доступен")
+                return True
+            logger.warning("Ответ сервера Google: %s", response.status)
             return False
-    except (urllib.error.URLError, socket.timeout) as e:
-        logger.warning(f"Интернет недоступен: {e}")
+    except (urllib.error.URLError, socket.timeout) as exc:
+        logger.warning("Интернет недоступен", exc_info=exc)
         return False
-    except Exception as e:
-        logger.error(f"Неожиданная ошибка при проверке интернета: {e}")
+    except Exception as exc:  # pragma: no cover - unexpected path
+        logger.error("Неожиданная ошибка при проверке интернета", exc_info=exc)
         return False

--- a/sync/notifications.py
+++ b/sync/notifications.py
@@ -22,7 +22,7 @@ class Notifier:
             except ImportError:
                 logger.debug("Plyer не установлен, используем Qt-уведомления")
             except Exception as e:
-                logger.warning(f"Ошибка системного уведомления: {e}")
+                logger.warning("Ошибка системного уведомления", exc_info=e)
 
             # Fallback на Qt-сообщения
             msg = QMessageBox(parent)
@@ -34,9 +34,8 @@ class Notifier:
             msg.exec_()
 
         except Exception as e:
-            logger.error(f"Ошибка показа уведомления: {e}")
-            # Последний резервный вариант - вывод в консоль
-            print(f"Уведомление: {title} - {message}")
+            logger.error("Ошибка показа уведомления", exc_info=e)
+            logger.info("Уведомление (fallback): %s - %s", title, message)
 
     @staticmethod
     def show_warning(title: str, message: str, parent=None):
@@ -49,8 +48,8 @@ class Notifier:
             msg.setIcon(QMessageBox.Warning)
             msg.exec_()
         except Exception as e:
-            logger.error(f"Ошибка показа предупреждения: {e}")
-            print(f"Предупреждение: {title} - {message}")
+            logger.error("Ошибка показа предупреждения", exc_info=e)
+            logger.warning("Предупреждение (fallback): %s - %s", title, message)
 
     @staticmethod
     def show_error(title: str, message: str, parent=None):
@@ -63,5 +62,5 @@ class Notifier:
             msg.setIcon(QMessageBox.Critical)
             msg.exec_()
         except Exception as e:
-            logger.error(f"Ошибка показа ошибки: {e}")
-            print(f"Ошибка: {title} - {message}")
+            logger.error("Ошибка показа ошибки", exc_info=e)
+            logger.error("Ошибка (fallback): %s - %s", title, message)

--- a/telegram_bot/main.py
+++ b/telegram_bot/main.py
@@ -1,14 +1,19 @@
 # telegram_bot/main.py
 from __future__ import annotations
-import logging, re, time, requests, os
-from typing import Optional
-from pathlib import Path
-from config import GOOGLE_SHEET_NAME, USERS_SHEET, TELEGRAM_BOT_TOKEN as CFG_TELEGRAM_BOT_TOKEN
-from sheets_api import SheetsAPI
 
-# --- Единое логирование для телеграм бота ---
+import logging
+import os
+import re
+import time
+from typing import Optional
+
+import requests
+
+from config import GOOGLE_SHEET_NAME, LOG_DIR, USERS_SHEET
+from config import TELEGRAM_BOT_TOKEN as CFG_TELEGRAM_BOT_TOKEN
 from logging_setup import setup_logging
-from config import LOG_DIR
+from sheets_api import SheetsAPI
+from telemetry import record_network_call
 
 # Инициализация логирования
 log_path = setup_logging(app_name="wtt-telebot", log_dir=LOG_DIR)
@@ -30,7 +35,11 @@ def _base() -> str:
     return f"https://api.telegram.org/bot{token}"
 
 def _send(chat_id: int | str, text: str) -> None:
-    requests.post(_base()+"/sendMessage", json={"chat_id": chat_id, "text": text, "parse_mode": "HTML"}, timeout=20)
+    payload = {"chat_id": chat_id, "text": text, "parse_mode": "HTML"}
+    with record_network_call("telegram.send_message"):
+        response = requests.post(_base() + "/sendMessage", json=payload, timeout=20)
+    if response.status_code >= 400:
+        log.warning("sendMessage responded with status %s", response.status_code)
 
 def _num_to_col(n: int) -> str:
     res = ""
@@ -81,10 +90,13 @@ def main():
             params = {"timeout": 60}
             if offset is not None:
                 params["offset"] = offset
-            r = requests.get(base+"/getUpdates", params=params, timeout=70)
-            data = r.json()
+            with record_network_call("telegram.get_updates"):
+                response = requests.get(base + "/getUpdates", params=params, timeout=70)
+            data = response.json()
             if not data.get("ok"):
-                time.sleep(2); continue
+                log.warning("getUpdates returned ok=False: %s", data)
+                time.sleep(2)
+                continue
             for upd in data.get("result", []):
                 offset = upd["update_id"] + 1
                 msg = upd.get("message") or {}
@@ -103,8 +115,9 @@ def main():
                     _send(chat_id, "Это не похоже на e-mail. Пришлите адрес вида <b>user@company.com</b>.")
         except KeyboardInterrupt:
             break
-        except Exception as e:
-            log.warning("Loop error: %s", e); time.sleep(3)
+        except Exception as exc:
+            log.warning("Loop error", exc_info=exc)
+            time.sleep(3)
 
 if __name__ == "__main__":
     main()

--- a/telegram_bot/notifier.py
+++ b/telegram_bot/notifier.py
@@ -1,10 +1,12 @@
 # telegram_bot/notifier.py
 from __future__ import annotations
-import logging, time
-from datetime import datetime, timezone
-from typing import Dict, Optional, Tuple, List
-import requests
+import logging
 import os
+import time
+from datetime import datetime, timezone
+from typing import Dict, List, Optional, Tuple
+
+import requests
 
 # Импорты из config.py с обработкой исключений на случай отсутствия модуля
 try:
@@ -28,6 +30,7 @@ except ImportError:
     CFG_TELEGRAM_SILENT = False
 
 from sheets_api import SheetsAPI
+from telemetry import record_network_call
 
 log = logging.getLogger(__name__)
 NOTIFICATIONS_LOG_SHEET = "NotificationsLog"
@@ -168,17 +171,21 @@ class TelegramNotifier:
             "disable_notification": self.default_silent if silent is None else bool(silent),
         }
         try:
-            # Модернизация: используем сессию с таймаутом
-            r = self._session.post(f"{self.api_url}/sendMessage", json=payload, timeout=self._timeout)
-            data = r.json()
+            with record_network_call("telegram.send_message"):
+                response = self._session.post(
+                    f"{self.api_url}/sendMessage",
+                    json=payload,
+                    timeout=self._timeout,
+                )
+            data = response.json()
             if not data.get("ok", False):
-                err = data.get("description") or r.text
+                err = data.get("description") or response.text
                 log.error("Telegram sendMessage error: %s", err)
                 return False, err
             return True, None
-        except Exception as e:
-            log.exception("Telegram sendMessage exception: %s", e)
-            return False, str(e)
+        except Exception as exc:
+            log.exception("Telegram sendMessage exception")
+            return False, str(exc)
 
     def _resolve_chat_id(self, email: str) -> Optional[str]:
         email = (email or "").strip().lower()

--- a/telemetry.py
+++ b/telemetry.py
@@ -1,0 +1,39 @@
+"""Helpers for telemetry and network call metrics."""
+from __future__ import annotations
+
+import logging
+import time
+from contextlib import contextmanager
+from typing import Iterator, Optional
+
+from logging_setup import correlation_context, get_session_id, new_request_id
+
+
+_metrics_logger = logging.getLogger("metrics")
+
+
+@contextmanager
+def record_network_call(name: str, *, session_id: Optional[str] = None) -> Iterator[str]:
+    """Context manager to capture metrics for outbound network calls."""
+
+    request_id = new_request_id()
+    effective_session = session_id or get_session_id()
+    with correlation_context(request_id=request_id, session_id=effective_session):
+        started_at = time.perf_counter()
+        try:
+            yield request_id
+        except Exception:
+            duration = time.perf_counter() - started_at
+            _metrics_logger.error(
+                "network_call name=%s status=error count=1 duration=%.3f",
+                name,
+                duration,
+            )
+            raise
+        else:
+            duration = time.perf_counter() - started_at
+            _metrics_logger.info(
+                "network_call name=%s status=success count=1 duration=%.3f",
+                name,
+                duration,
+            )

--- a/tools/audit_api_surface.py
+++ b/tools/audit_api_surface.py
@@ -11,9 +11,15 @@
 import ast
 import argparse
 import inspect
+import logging
 import os
 from pathlib import Path
-from typing import Dict, Set, List, Tuple
+from typing import Dict, List, Set, Tuple
+
+from logging_setup import setup_logging
+
+
+logger = logging.getLogger(__name__)
 
 PROJECT_EXTS = {".py"}
 
@@ -76,20 +82,21 @@ def main():
         except Exception:
             pass
 
-    print("=== SheetsAPI surface (public) ===")
+    logger.info("=== SheetsAPI surface (public) ===")
     for m in sorted(api_methods):
-        print(" -", m)
-    print("\n=== Calls found in project ===")
+        logger.info(" - %s", m)
+    logger.info("=== Calls found in project ===")
     missing = []
     for m in sorted(found.keys()):
-        print(f"\n{m}:")
+        logger.info("%s:", m)
         for recv, kw in sorted(found[m]):
-            print(f"  recv={recv}, kwargs={kw}")
+            logger.info("  recv=%s, kwargs=%s", recv, kw)
         if m not in api_methods:
             missing.append(m)
-    print("\n=== Missing in SheetsAPI ===")
+    logger.info("=== Missing in SheetsAPI ===")
     for m in missing:
-        print(" *", m)
+        logger.info(" * %s", m)
 
 if __name__ == "__main__":
+    setup_logging(app_name="wtt-audit-api", force_console=True)
     main()

--- a/tools/debug_worklogs.py
+++ b/tools/debug_worklogs.py
@@ -1,39 +1,44 @@
 import logging
-from sheets_api import get_sheets_api
+
 from config import DEFAULT_WORKLOG_GROUP, normalize_group_name
+from logging_setup import setup_logging
+from sheets_api import get_sheets_api
 
-logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 
-def print_headers(ws):
+logger = logging.getLogger(__name__)
+
+
+def print_headers(ws) -> None:
     try:
         headers = get_sheets_api()._request_with_retry(ws.row_values, 1)
-    except Exception as e:
-        print("   [ERR] не удалось прочитать шапку:", e)
+    except Exception as exc:
+        logger.error("Не удалось прочитать шапку", exc_info=exc)
         return
-    print("   Шапка:", headers)
+    logger.info("Шапка: %s", headers)
 
-def main():
+
+def main() -> None:
     api = get_sheets_api()
-    # Список вкладок
     try:
         titles = api._list_titles()
-        print("Доступные вкладки:")
-        for t in titles:
-            print(" -", t)
-    except Exception as e:
-        print("Не удалось получить список вкладок:", e)
+        logger.info("Доступные вкладки:")
+        for title in titles:
+            logger.info(" - %s", title)
+    except Exception as exc:
+        logger.error("Не удалось получить список вкладок", exc_info=exc)
         return
-    print()
 
-    # Проверим резолвинг по нескольким группам
-    for grp in [None, DEFAULT_WORKLOG_GROUP, "Стоматология", "Тест"]:
-        g = normalize_group_name(grp or "")
+    logger.info("")
+    for group in [None, DEFAULT_WORKLOG_GROUP, "Стоматология", "Тест"]:
+        normalized = normalize_group_name(group or "")
         try:
-            ws = api._resolve_worklog_ws(g)
-            print(f"[OK] group={grp!r} -> {ws.title}")
-            print_headers(ws)
-        except Exception as e:
-            print(f"[ERR] group={grp!r}: {e}")
+            worksheet = api._resolve_worklog_ws(normalized)
+            logger.info("group=%r -> %s", group, worksheet.title)
+            print_headers(worksheet)
+        except Exception as exc:
+            logger.error("group=%r: ошибка", group, exc_info=exc)
+
 
 if __name__ == "__main__":
+    setup_logging(app_name="wtt-debug-worklogs", force_console=True)
     main()

--- a/tools/doctor.py
+++ b/tools/doctor.py
@@ -16,6 +16,9 @@ from sheets_api import get_sheets_api
 
 from notifications.rules_manager import RULES_SHEET
 
+
+logger = logging.getLogger(__name__)
+
 # Минимальные ожидания под вашу фактическую схему:
 EXPECTED = {
     "Users": ["Email", "Name", "Group"],  # базовые атрибуты пользователя
@@ -193,7 +196,7 @@ def run(out: Path) -> None:
         out_path.write_text(render_markdown(report), encoding="utf-8")
     else:
         out_path.write_text(json.dumps(report, ensure_ascii=False, indent=2), encoding="utf-8")
-    print(f"OK: written {out_path}")
+    logger.info("Отчёт записан: %s", out_path)
 
 
 def main():
@@ -217,7 +220,6 @@ def main():
     level = logging.DEBUG if args.debug else (getattr(logging, args.log_level, None) if args.log_level else None)
     force_console = True if (args.debug or args.console) else None
     setup_logging(app_name="wtt-doctor", log_dir=LOG_DIR, level=level, force_console=force_console)
-    logger = logging.getLogger(__name__)
     
     # --- Проверка NotificationRules: булево в MessageTemplate ---
     try:
@@ -236,9 +238,12 @@ def main():
                     if v in ("TRUE","FALSE"):
                         bad.append(r)
                 if bad:
-                    print(f"WARNING: {len(bad)} rule(s) have boolean in MessageTemplate; default text will be used.")
+                    logger.warning(
+                        "%d rule(s) have boolean in MessageTemplate; default text will be used.",
+                        len(bad),
+                    )
     except Exception as e:
-        print(f"Doctor: rules check skipped: {e}")
+        logger.warning("Rules check skipped", exc_info=e)
     
     run(Path(args.output))
 

--- a/tools/sheets_bootstrap.py
+++ b/tools/sheets_bootstrap.py
@@ -1,33 +1,62 @@
-+ # tools/sheets_bootstrap.py
-+ from __future__ import annotations
-+ import sys
-+ from sheets_api import SheetsAPI
-+ from config import GOOGLE_SHEET_NAME
-+
-+ _USERS_HEADER = ["Email","Name","Group","TelegramChatId"]
-+ _GROUPS_HEADER = ["Group","TelegramTopicId"]
-+ _ACCESS_HEADER = ["Email","IsAdmin"]
-+ _RULES_HEADER = ["RuleId","Type","Target","ThresholdMinutes","CooldownMinutes","Enabled","Comment"]
-+ _LOG_HEADER = ["TsUtc","Type","Scope","Target","Message","Sent","Error"]
-+
-+ def ensure_header(api: SheetsAPI, title: str, header: list[str]) -> None:
-+     ws = api.worksheet(title)
-+     rows = api.values_get(f"'{title}'!1:1") or []
-+     have = rows[0] if rows else []
-+     if have != header:
-+         api.values_update(f"'{title}'!1:1", header)
-+
-+ def main():
-+     api = SheetsAPI(GOOGLE_SHEET_NAME)
-+     for title, hdr in [
-+         ("Users", _USERS_HEADER),
-+         ("Groups", _GROUPS_HEADER),
-+         ("AccessControl", _ACCESS_HEADER),
-+         ("NotificationRules", _RULES_HEADER),
-+         ("NotificationsLog", _LOG_HEADER),
-+     ]:
-+         ensure_header(api, title, hdr)
-+     print("OK: bootstrap done")
-+
-+ if __name__ == "__main__":
-+     sys.exit(main())
+# tools/sheets_bootstrap.py
+from __future__ import annotations
+
+import logging
+import sys
+
+from logging_setup import setup_logging
+from config import GOOGLE_SHEET_NAME
+from sheets_api import SheetsAPI
+
+
+logger = logging.getLogger(__name__)
+
+
+_USERS_HEADER = ["Email", "Name", "Group", "TelegramChatId"]
+_GROUPS_HEADER = ["Group", "TelegramTopicId"]
+_ACCESS_HEADER = ["Email", "IsAdmin"]
+_RULES_HEADER = [
+    "RuleId",
+    "Type",
+    "Target",
+    "ThresholdMinutes",
+    "CooldownMinutes",
+    "Enabled",
+    "Comment",
+]
+_LOG_HEADER = [
+    "TsUtc",
+    "Type",
+    "Scope",
+    "Target",
+    "Message",
+    "Sent",
+    "Error",
+]
+
+
+def ensure_header(api: SheetsAPI, title: str, header: list[str]) -> None:
+    _ = api.worksheet(title)
+    rows = api.values_get(f"'{title}'!1:1") or []
+    have = rows[0] if rows else []
+    if have != header:
+        api.values_update(f"'{title}'!1:1", header)
+
+
+def main() -> int:
+    setup_logging(app_name="wtt-sheets-bootstrap", force_console=True)
+    api = SheetsAPI(GOOGLE_SHEET_NAME)
+    for title, hdr in [
+        ("Users", _USERS_HEADER),
+        ("Groups", _GROUPS_HEADER),
+        ("AccessControl", _ACCESS_HEADER),
+        ("NotificationRules", _RULES_HEADER),
+        ("NotificationsLog", _LOG_HEADER),
+    ]:
+        ensure_header(api, title, hdr)
+    logger.info("Bootstrap completed for %s", GOOGLE_SHEET_NAME)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/tg_envcheck.py
+++ b/tools/tg_envcheck.py
@@ -1,10 +1,17 @@
 from __future__ import annotations
+
+import logging
 import os
+
+from logging_setup import setup_logging
 from config import (
     TELEGRAM_BOT_TOKEN as CFG_TELEGRAM_BOT_TOKEN,
     TELEGRAM_ADMIN_CHAT_ID as CFG_TELEGRAM_ADMIN_CHAT_ID,
     TELEGRAM_BROADCAST_CHAT_ID as CFG_TELEGRAM_BROADCAST_CHAT_ID,
 )
+
+
+logger = logging.getLogger(__name__)
 
 def _mask(s: str, keep=6) -> str:
     if not s:
@@ -12,14 +19,16 @@ def _mask(s: str, keep=6) -> str:
     s = str(s)
     return s[:keep] + "..." if len(s) > keep else s
 
-def main():
-    print("=== TELEGRAM effective settings ===")
+def main() -> int:
+    setup_logging(app_name="wtt-tg-envcheck", force_console=True)
+    logger.info("TELEGRAM effective settings")
     tok = (CFG_TELEGRAM_BOT_TOKEN or os.getenv("TELEGRAM_BOT_TOKEN", ""))
     adm = (CFG_TELEGRAM_ADMIN_CHAT_ID or os.getenv("TELEGRAM_ADMIN_CHAT_ID", ""))
     brc = (CFG_TELEGRAM_BROADCAST_CHAT_ID or os.getenv("TELEGRAM_BROADCAST_CHAT_ID", ""))
-    print("TELEGRAM_BOT_TOKEN:", "set" if tok else "EMPTY", _mask(tok))
-    print("TELEGRAM_ADMIN_CHAT_ID:", adm or "<empty>")
-    print("TELEGRAM_BROADCAST_CHAT_ID:", brc or "<empty>")
+    logger.info("TELEGRAM_BOT_TOKEN status=%s value=%s", "set" if tok else "EMPTY", _mask(tok))
+    logger.info("TELEGRAM_ADMIN_CHAT_ID value=%s", adm or "<empty>")
+    logger.info("TELEGRAM_BROADCAST_CHAT_ID value=%s", brc or "<empty>")
+    return 0
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/tools/tg_send.py
+++ b/tools/tg_send.py
@@ -1,11 +1,17 @@
 # tools/tg_send.py
 from __future__ import annotations
-import argparse, logging
+
+import argparse
+import logging
+
+from logging_setup import setup_logging
 from telegram_bot.notifier import TelegramNotifier
 
-logging.basicConfig(level=logging.INFO)
 
-def main():
+logger = logging.getLogger(__name__)
+
+
+def main() -> int:
     ap = argparse.ArgumentParser("Отправка уведомлений в Telegram")
     ap.add_argument("--type", choices=["service", "personal", "group"], required=True)
     ap.add_argument("--email", help="для personal: e-mail сотрудника")
@@ -23,7 +29,12 @@ def main():
         ok = n.send_personal(args.email, args.text, silent=args.silent)
     else:
         ok = n.send_group(args.text, group=None if args.all else args.group, for_all=args.all, silent=args.silent)
-    print("OK" if ok else "FAIL")
+    if ok:
+        logger.info("Telegram notification sent")
+        return 0
+    logger.error("Telegram notification failed")
+    return 1
 
 if __name__ == "__main__":
-    main()
+    setup_logging(app_name="wtt-tg-send", force_console=True)
+    raise SystemExit(main())

--- a/user_app/db_local.py
+++ b/user_app/db_local.py
@@ -889,7 +889,9 @@ def write_tx_external(db_path: Optional[str] = None):
 
 if __name__ == "__main__":
     import argparse
+    from logging_setup import setup_logging
 
+    setup_logging(app_name="wtt-db-local", force_console=True)
     ap = argparse.ArgumentParser(description="LocalDB helper")
     ap.add_argument("--path", type=str, default=str(LOCAL_DB_PATH))
     ap.add_argument("--add-log", type=str, default=None, help="Добавить app_log (level:msg)")
@@ -903,10 +905,10 @@ if __name__ == "__main__":
         except Exception:
             level, msg = "INFO", args.add_log
         rid = db.add_log(level, msg)
-        print(f"Inserted app_log id={rid}")
+        logger.info("Inserted app_log id=%s", rid)
 
     if args.cleanup_days is not None:
         cnt = db.cleanup_old_logs(days=args.cleanup_days)
-        print(f"Deleted {cnt} old app_log rows")
+        logger.info("Deleted %s old app_log rows", cnt)
 
     db.close()

--- a/user_app/gui.py
+++ b/user_app/gui.py
@@ -563,13 +563,16 @@ class EmployeeApp(QWidget):
         super().closeEvent(event)
 
 if __name__ == "__main__":
+    from logging_setup import setup_logging
+
+    setup_logging(app_name="wtt-user-gui", force_console=True)
     app = QApplication(sys.argv)
     window = EmployeeApp(
         email="test@example.com",
         name="Тестовый Сотрудник",
         role="специалист",
         group="Тестовая группа",
-        on_logout_callback=lambda reason: print(f"Logout reason: {reason}")
+        on_logout_callback=lambda reason: logger.info("Logout reason: %s", reason)
     )
     window.show()
     sys.exit(app.exec())

--- a/user_app/login_window.py
+++ b/user_app/login_window.py
@@ -397,7 +397,9 @@ class LoginWindow(QDialog):
 
 if __name__ == "__main__":
     from PyQt5.QtWidgets import QApplication
-    logging.basicConfig(level=logging.DEBUG)
+    from logging_setup import setup_logging
+
+    setup_logging(app_name="wtt-login-window", force_console=True)
     app = QApplication(sys.argv)
     window = LoginWindow()
     window.show()

--- a/user_app/session.py
+++ b/user_app/session.py
@@ -1,7 +1,12 @@
 # user_app/session.py
 from __future__ import annotations
-from typing import Optional
 import threading
+from typing import Optional
+
+from logging_setup import (
+    get_session_id as _get_log_session_id,
+    set_session_id as _set_log_session_id,
+)
 
 # Простой потокобезопасный storage для текущих реквизитов сессии
 _lock = threading.RLock()
@@ -20,8 +25,11 @@ def get_user_email() -> Optional[str]:
 def set_session_id(session_id: str) -> None:
     global _current_session_id
     with _lock:
-        _current_session_id = (session_id or "").strip()
+        normalized = (session_id or "").strip()
+        _current_session_id = normalized
+        _set_log_session_id(normalized)
 
 def get_session_id() -> Optional[str]:
     with _lock:
-        return _current_session_id
+        session_id = _current_session_id or _get_log_session_id()
+        return session_id if session_id and session_id != "-" else None


### PR DESCRIPTION
## Summary
- introduce correlation-aware ISO-8601 logging formatter and expose helpers for managing request/session identifiers
- add `telemetry.record_network_call` to emit metrics and wrap network usage across Sheets API and Telegram clients
- replace ad-hoc prints in CLI/utilities with structured logging configured through `setup_logging`

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68cbc24959488327a1b6d860bb77d69d