### PR TITLE
Implement consistent logout flow and remote session handling

### DIFF
--- a/user_app/api.py
+++ b/user_app/api.py
@@ -69,6 +69,15 @@ class UserAPI:
         st = self.sheets.check_user_session_status(email=email, session_id=session_id)
         return st in ("kicked", "finished")
 
+    def get_session_status(self, email: str, session_id: str) -> str | None:
+        try:
+            return self.sheets.check_user_session_status(
+                email=email, session_id=session_id
+            )
+        except Exception as exc:  # pragma: no cover - сетевые ошибки не критичны
+            logger.debug("get_session_status failed for %s: %s", session_id, exc)
+            return None
+
     # ---- WorkLog ----
     def log_actions(
         self, actions: list[dict], email: str, user_group: str | None = None

--- a/user_app/gui.py
+++ b/user_app/gui.py
@@ -1,6 +1,7 @@
 import logging
 import sys
 import threading
+import time
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Callable, Optional
@@ -11,6 +12,7 @@ sys.path.insert(0, str(PROJECT_ROOT))
 from config import MAX_COMMENT_LENGTH, STATUS_GROUPS
 from sheets_api import SheetsAPIError, get_sheets_api
 from user_app.db_local import LocalDB, LocalDBError, write_tx
+from user_app.signals import SessionSignals
 
 try:
     from sync.notifications import Notifier
@@ -52,6 +54,8 @@ class EmployeeApp(QWidget):
         on_logout_callback: Optional[Callable] = None,
         session_id: Optional[str] = None,
         login_was_performed: bool = True,
+        session_signals: Optional[SessionSignals] = None,
+        on_session_finish_requested: Optional[Callable[[str], None]] = None,
     ):
         super().__init__()
         self.email = email
@@ -61,12 +65,15 @@ class EmployeeApp(QWidget):
         self.shift_hours = shift_hours
         self.telegram_login = telegram_login
         self.on_logout_callback = on_logout_callback
+        self.session_signals = session_signals
+        self.on_session_finish_requested = on_session_finish_requested
 
         self.current_status = "В работе"
         self.status_start_time = datetime.now()
         self.shift_start_time = datetime.now()
         self.last_sync_time = None
         self.shift_ended = False
+        self._logout_in_progress = False
 
         # Логика закрытия: None, "admin_logout", "user_close", "auto_logout"
         self._closing_reason = "user_close"  # по умолчанию
@@ -205,6 +212,139 @@ class EmployeeApp(QWidget):
                 "Оффлайн режим", "Предыдущий статус будет синхронизирован позже."
             )
 
+    def _notify_session_finish_requested(self, reason: str) -> None:
+        if callable(self.on_session_finish_requested):
+            try:
+                self.on_session_finish_requested(reason)
+            except Exception as exc:
+                logger.debug("on_session_finish_requested failed: %s", exc)
+
+    def _disable_post_logout(self) -> None:
+        self.shift_ended = True
+        self.finish_btn.setEnabled(False)
+        for btn in self.status_buttons.values():
+            btn.setEnabled(False)
+
+    def _emit_session_finished(self, reason: str) -> None:
+        self._logout_in_progress = False
+        if self.session_signals:
+            try:
+                self.session_signals.sessionFinished.emit(reason)
+                return
+            except Exception as exc:
+                logger.debug("sessionFinished emit failed: %s", exc)
+        if callable(self.on_logout_callback):
+            try:
+                self.on_logout_callback(reason)
+            except TypeError:
+                self.on_logout_callback()
+
+    def _start_logout_worker(self, mode: str) -> None:
+        threading.Thread(
+            target=self._logout_worker,
+            args=(mode,),
+            daemon=True,
+        ).start()
+
+    def _logout_worker(self, mode: str) -> None:
+        reason = "local_logout"
+        try:
+            if mode == "local":
+                success, offline = self._finish_remote_session_with_retry()
+                if offline and not success:
+                    reason = "local_logout_offline"
+                else:
+                    reason = "local_logout"
+            elif mode == "remote":
+                self._ack_remote_command_with_retry()
+                reason = "remote_force_logout"
+            else:
+                reason = mode
+        finally:
+            self._emit_session_finished(reason)
+
+    def _finish_remote_session_with_retry(self) -> tuple[bool, bool]:
+        """Возвращает (success, offline_hint)."""
+
+        if not self.sheets_api:
+            return False, False
+
+        last_exception: Exception | None = None
+        for attempt in range(1, 4):
+            try:
+                logout_time = datetime.now().isoformat()
+                ok = self.sheets_api.finish_active_session(
+                    self.email,
+                    self.session_id,
+                    logout_time,
+                )
+                if ok:
+                    logger.info(
+                        "finish_active_session succeeded for %s (attempt %s)",
+                        self.session_id,
+                        attempt,
+                    )
+                    return True, False
+
+                status = (
+                    (
+                        self.sheets_api.check_user_session_status(
+                            self.email, self.session_id
+                        )
+                        or ""
+                    )
+                    .strip()
+                    .lower()
+                )
+                if status and status != "active":
+                    logger.info(
+                        "finish_active_session skipped: remote status %s for %s",
+                        status,
+                        self.session_id,
+                    )
+                    return True, False
+            except Exception as exc:
+                last_exception = exc
+                logger.warning(
+                    "finish_active_session attempt %s failed: %s",
+                    attempt,
+                    exc,
+                )
+            time.sleep(2)
+
+        offline = last_exception is not None
+        if offline:
+            logger.warning(
+                "finish_active_session failed after retries for %s: %s",
+                self.session_id,
+                last_exception,
+            )
+        else:
+            logger.warning(
+                "finish_active_session returned False for %s after retries",
+                self.session_id,
+            )
+        return False, offline
+
+    def _ack_remote_command_with_retry(self) -> None:
+        if not hasattr(self.sheets_api, "ack_remote_command"):
+            return
+        for attempt in range(1, 4):
+            try:
+                ok = self.sheets_api.ack_remote_command(
+                    email=self.email, session_id=self.session_id
+                )
+                if ok:
+                    logger.info(
+                        "ACK remote command sent for %s on attempt %s",
+                        self.session_id,
+                        attempt,
+                    )
+                    return
+            except Exception as exc:
+                logger.debug("ack_remote_command attempt %s failed: %s", attempt, exc)
+            time.sleep(2)
+
     def _init_db(self):
         try:
             self.db = LocalDB()
@@ -336,16 +476,21 @@ class EmployeeApp(QWidget):
 
     def _is_session_finished_remote(self) -> bool:
         """
-        True — если по (email, session_id) в ActiveSessions статус 'finished' или 'kicked'.
+        True — если по (email, session_id) в ActiveSessions статус 'finished', 'kicked' или 'force_logout'.
         """
         try:
-            row = self.sheets_api.check_user_session_status(self.email, self.session_id)
-            if isinstance(row, dict):
-                st = (row.get("Status") or "").strip().lower()
+            status = self.sheets_api.check_user_session_status(
+                self.email, self.session_id
+            )
+            if isinstance(status, dict):
+                st = (status.get("Status") or "").strip().lower()
+            else:
+                st = str(status or "").strip().lower()
+            if st:
                 logger.debug(
                     f"[ACTIVESESSIONS] status for {self.email}/{self.session_id}: {st}"
                 )
-                return st in ("finished", "kicked")
+            return st in {"finished", "kicked", "force_logout"}
         except Exception as e:
             logger.debug(f"_is_session_finished_remote error: {e}")
         return False
@@ -371,25 +516,21 @@ class EmployeeApp(QWidget):
             logger.info(
                 f"[AUTO_LOGOUT_DETECT] В ActiveSessions статус НЕ active для {self.email}, session={self.session_id}"
             )
-            self._closing_reason = "auto_logout"
-            self.finish_btn.setEnabled(False)
-            for btn in self.status_buttons.values():
-                btn.setEnabled(False)
-            Notifier.show("WorkLog", "Смена завершена администратором.")
-            try:
-                self._log_shift_end(
-                    "Разлогинен администратором (удалённо)", reason="admin"
-                )
-            except Exception as e:
-                logger.error(f"Ошибка при автологаутах по сигналу из Sheets: {e}")
-            self.shift_ended = True
-            self.close()
+            self.force_logout_by_admin()
+            return
 
     def force_logout_by_admin(self):
         """
         Слот под SyncSignals.force_logout.
         Вызывается без аргументов. Показываем предупреждение и закрываемся.
         """
+        if self._logout_in_progress:
+            return
+
+        self._logout_in_progress = True
+        self._closing_reason = "remote_force_logout"
+        self._notify_session_finish_requested("remote_force_logout")
+
         try:
             QMessageBox.warning(
                 self,
@@ -398,14 +539,30 @@ class EmployeeApp(QWidget):
             )
         except Exception:
             pass
-        self._closing_reason = "admin_logout"
-        # Передаём reason в on_logout_callback, если он его принимает
-        if callable(self.on_logout_callback):
+
+        record_id = -1
+        try:
+            record_id = self._log_shift_end(
+                "Сессия завершена администратором",
+                reason="FORCE_LOGOUT",
+                sync_to_sheets=False,
+            )
+        except Exception as exc:
+            logger.error(f"Ошибка фиксации принудительного выхода: {exc}")
+
+        if record_id and record_id > 0:
             try:
-                self.on_logout_callback(self._closing_reason)
-            except TypeError:
-                self.on_logout_callback()
-        self.close()
+                self.db.mark_actions_synced([record_id])
+            except Exception as sync_exc:
+                logger.debug(
+                    "Не удалось пометить запись FORCE_LOGOUT синхронизированной: %s",
+                    sync_exc,
+                )
+
+        self._disable_post_logout()
+        self.comment_input.clear()
+        Notifier.show("WorkLog", "Сессия завершается администратором")
+        self._start_logout_worker("remote")
 
     def _update_info_text(self):
         info_text = (
@@ -532,33 +689,57 @@ class EmployeeApp(QWidget):
         self._update_info_text()
         Notifier.show("WorkLog", f"Статус изменён на: {new_status}")
 
-    def _log_shift_end(self, comment: str, reason: str = "user"):
+    def _log_shift_end(
+        self, comment: str, reason: str = "LOGOUT", sync_to_sheets: bool = True
+    ) -> int:
         now = datetime.now().isoformat()
+        status_value = reason or "LOGOUT"
+        record_id = -1
         try:
             with write_tx() as conn:
                 # Завершаем последний статус
-                self.db.finish_last_status_tx(conn, self.email, self.session_id, now)
+                try:
+                    self.db.finish_last_status_tx(
+                        conn, self.email, self.session_id, now, reason=status_value
+                    )
+                except TypeError:
+                    self.db.finish_last_status_tx(
+                        conn, self.email, self.session_id, now
+                    )
 
                 # Логируем завершение смены
                 record_id = self.db.log_action_tx(
                     conn=conn,
                     email=self.email,
                     name=self.name,
-                    status="LOGOUT",
+                    status=status_value,
                     action_type="LOGOUT",
                     comment=comment,
                     session_id=self.session_id,
                     status_start_time=now,
                     status_end_time=now,
-                    reason=reason,
+                    reason=status_value,
+                    user_group=self.group,
                 )
-            self._send_action_to_sheets(record_id, user_group=self.group)
+            if record_id and record_id > 0:
+                if sync_to_sheets:
+                    self._send_action_to_sheets(record_id, user_group=self.group)
+                else:
+                    try:
+                        self.db.mark_actions_synced([record_id])
+                    except Exception as sync_exc:
+                        logger.debug(
+                            "mark_actions_synced failed for record %s: %s",
+                            record_id,
+                            sync_exc,
+                        )
+            return record_id
         except Exception as e:
             logger.error(f"Ошибка записи завершения смены: {e}")
             raise
 
     def finish_shift(self):
-        if self.shift_ended:
+        if self.shift_ended or self._logout_in_progress:
             QMessageBox.information(self, "Информация", "Смена уже завершена")
             return
 
@@ -566,77 +747,22 @@ class EmployeeApp(QWidget):
         if not comment:
             comment = "Завершение смены"
 
+        self._logout_in_progress = True
+        self._closing_reason = "local_logout"
+        self._notify_session_finish_requested("local_logout")
+
         try:
-            self._log_shift_end(comment)
+            self._log_shift_end(comment, reason="LOGOUT", sync_to_sheets=True)
         except Exception:
+            self._logout_in_progress = False
+            self._closing_reason = "user_close"
             QMessageBox.critical(self, "Ошибка", "Не удалось завершить смену")
             return
 
-        self.shift_ended = True
-        self.finish_btn.setEnabled(False)
-        for btn in self.status_buttons.values():
-            btn.setEnabled(False)
-
-        # === Обновление ActiveSessions ===
-        try:
-            lt = datetime.now().isoformat()
-            ok = self.sheets_api.finish_active_session(self.email, self.session_id, lt)
-            logger.info(
-                f"[LOGOUT/ActiveSessions] finish_active_session({self.email}, {self.session_id}) -> {ok}"
-            )
-            if not ok:
-                # Фоллбэк: обновим ПОСЛЕДНЮЮ активную строку по email (если есть) как 'finished'
-                try:
-                    # Универсальный путь через _update_session_status если доступен
-                    if hasattr(self.sheets_api, "_update_session_status"):
-                        ok2 = self.sheets_api._update_session_status(
-                            self.email, self.session_id, "finished", lt
-                        )
-                        logger.warning(
-                            f"[LOGOUT/ActiveSessions] fallback _update_session_status -> {ok2}"
-                        )
-                        ok = ok or ok2
-                    else:
-                        ok2 = self.sheets_api.kick_active_session(
-                            session_id=self.session_id,
-                            email=self.email,
-                            logout_time=lt,
-                        )  # меняет статус, но приемлемо
-                        logger.warning(
-                            f"[LOGOUT/ActiveSessions] fallback kick_active_session -> {ok2}"
-                        )
-                        ok = ok or ok2
-                except Exception as e2:
-                    logger.error(f"[LOGOUT/ActiveSessions] fallback error: {e2}")
-
-            # Верификация статуса
-            try:
-                st = (
-                    (
-                        self.sheets_api.check_user_session_status(
-                            self.email, self.session_id
-                        )
-                        or ""
-                    )
-                    .strip()
-                    .lower()
-                )
-                logger.info(f"[LOGOUT/ActiveSessions] post-check status: {st}")
-                if st == "active":
-                    # одна повторная попытка
-                    ok3 = self.sheets_api.finish_active_session(
-                        self.email, self.session_id, lt
-                    )
-                    logger.warning(
-                        f"[LOGOUT/ActiveSessions] repeat finish_active_session -> {ok3}"
-                    )
-            except Exception as e3:
-                logger.warning(f"[LOGOUT/ActiveSessions] status verify error: {e3}")
-        except Exception as e:
-            logger.error(f"Ошибка завершения сессии в ActiveSessions: {e}")
-
-        Notifier.show("WorkLog", "Смена завершена")
-        QMessageBox.information(self, "Успех", "Смена завершена успешно")
+        self._disable_post_logout()
+        self.comment_input.clear()
+        Notifier.show("WorkLog", "Идёт завершение смены")
+        self._start_logout_worker("local")
 
     def closeEvent(self, event):
         if not self.shift_ended:

--- a/user_app/main.py
+++ b/user_app/main.py
@@ -1,5 +1,6 @@
 # user_app/main.py
 import atexit
+import datetime as dt
 import logging
 import sys
 import threading
@@ -28,9 +29,10 @@ from config import (
 from logging_setup import setup_logging
 from notifications.engine import start_background_poller
 from sheets_api import SheetsAPI  # Явный импорт класса SheetsAPI
-from user_app import db_local  # ← добавили импорт
+from user_app import db_local
+from user_app import session as session_state  # ← добавили импорт
 from user_app.api import UserAPI
-from user_app.signals import SyncSignals
+from user_app.signals import SessionSignals, SyncSignals
 
 atexit.register(db_local.close_connection)
 
@@ -48,7 +50,13 @@ class ApplicationSignals(QObject):
 
 
 def _hb_loop(
-    api: UserAPI, session_id: str, stop_evt: threading.Event, period_sec: int
+    api: UserAPI,
+    email: str | None,
+    session_id: str,
+    stop_evt: threading.Event,
+    period_sec: int,
+    session_signals: "SessionSignals" | None = None,
+    suppress_evt: threading.Event | None = None,
 ) -> None:
     logger = logging.getLogger(__name__)
 
@@ -59,9 +67,40 @@ def _hb_loop(
     if period <= 0:
         period = 60
 
+    active_statuses = {"active", "в работе"}
+    remote_emitted = False
+
+    def _check_remote() -> None:
+        nonlocal remote_emitted
+        if remote_emitted or not session_signals or not email:
+            return
+        if suppress_evt and suppress_evt.is_set():
+            return
+        try:
+            status = (
+                (api.get_session_status(email=email, session_id=session_id) or "")
+                .strip()
+                .lower()
+            )
+        except (
+            Exception
+        ) as exc:  # pragma: no cover - доп. страховка от неожиданных исключений
+            logger.debug("Heartbeat remote check failed: %s", exc)
+            return
+        if status and status not in active_statuses:
+            remote_emitted = True
+            logger.info(
+                "Heartbeat detected non-active status (session=%s, status=%s)",
+                session_id,
+                status,
+            )
+            session_signals.sessionFinished.emit("remote_force_logout")
+            stop_evt.set()
+
     def _send_once() -> None:
         try:
             api.heartbeat_session(session_id=session_id)
+            _check_remote()
         except Exception as exc:
             logger.warning("Heartbeat thread error for session %s: %s", session_id, exc)
 
@@ -84,12 +123,16 @@ class ApplicationManager(QObject):
         self.login_window = None
         self.main_window = None
         self.signals = ApplicationSignals()
+        self.session_signals = SessionSignals()
+        self.session_signals.sessionFinished.connect(self._handle_session_finished)
 
         self.sync_thread: QThread | None = None
         self.sync_worker: SyncManager | None = None
         self.sync_signals = (
             SyncSignals()
         )  # сигналы доступны и для GUI, и для SyncManager
+        self._sync_running = False
+        self._sync_offline_mode = False
 
         sys.excepthook = self.handle_uncaught_exception
 
@@ -98,6 +141,10 @@ class ApplicationManager(QObject):
         self._heartbeat_thread: threading.Thread | None = None
         self._heartbeat_period = HEARTBEAT_PERIOD_SEC
         self._current_session_id: str | None = None
+        self._current_user_email: str | None = None
+        self._pending_finish_reason: str | None = None
+        self._returning_to_login = False
+        self._suppress_remote_checks = threading.Event()
 
         offline_mode = False
         try:
@@ -179,7 +226,15 @@ class ApplicationManager(QObject):
 
         thread = threading.Thread(
             target=_hb_loop,
-            args=(self.user_api, session_id, stop_evt, period_value),
+            args=(
+                self.user_api,
+                self._current_user_email,
+                session_id,
+                stop_evt,
+                period_value,
+                self.session_signals,
+                self._suppress_remote_checks,
+            ),
             daemon=True,
             name="session-heartbeat",
         )
@@ -232,8 +287,31 @@ class ApplicationManager(QObject):
             )  # run() есть в SyncManager
             self.sync_thread.start()
             logger.info("Sync service thread started (offline_mode=%s)", offline_mode)
+            self._sync_running = True
+            self._sync_offline_mode = offline_mode
         except Exception as e:
             logger.error(f"Failed to start sync service: {e}")
+
+    def _stop_sync_service(self) -> None:
+        logger = logging.getLogger(__name__)
+        if not self.sync_thread and not self.sync_worker:
+            self._sync_running = False
+            return
+
+        try:
+            if self.sync_worker:
+                try:
+                    self.sync_worker.stop()
+                except Exception as exc:  # pragma: no cover - безопасная остановка
+                    logger.debug("Sync worker stop error: %s", exc)
+        finally:
+            if self.sync_thread and self.sync_thread.isRunning():
+                self.sync_thread.quit()
+                self.sync_thread.wait(2000)
+
+        self.sync_thread = None
+        self.sync_worker = None
+        self._sync_running = False
 
     # --- UI потоки ---
     def show_login_window(self):
@@ -267,6 +345,9 @@ class ApplicationManager(QObject):
             if "login_was_performed" in user_data:
                 login_was_performed = bool(user_data["login_was_performed"])
 
+            self._suppress_remote_checks.clear()
+            self._pending_finish_reason = None
+
             def on_logout_wrapper(reason: str | None = None):
                 """
                 Колбэк из EmployeeApp при закрытии/логауте.
@@ -274,6 +355,8 @@ class ApplicationManager(QObject):
                 Сейчас логика простая — просто корректно завершаем приложение.
                 При желании здесь можно добавить отдельную запись в логи/Sheets.
                 """
+                if reason == "return_to_login":
+                    return
                 self.quit_application()
 
             # создаём главное окно как раньше
@@ -287,6 +370,8 @@ class ApplicationManager(QObject):
                 session_id=session_id,
                 login_was_performed=login_was_performed,
                 group=user_data.get("group", ""),
+                session_signals=self.session_signals,
+                on_session_finish_requested=self.handle_session_finish_requested,
             )
             self.main_window.show()
 
@@ -298,7 +383,17 @@ class ApplicationManager(QObject):
             logger.info("force_logout сигнал подключён к force_logout_by_admin")
 
             actual_session_id = getattr(self.main_window, "session_id", session_id)
+            self._current_session_id = actual_session_id
+            self._current_user_email = user_data.get("email")
             self._start_session_heartbeat(actual_session_id)
+            try:
+                session_state.set_session_id(actual_session_id or "")
+                session_state.set_user_email(self._current_user_email or "")
+            except Exception:
+                logger.debug("Unable to persist session id in session_state")
+
+            if not self._sync_running:
+                self._start_sync_service(offline_mode=self._sync_offline_mode)
 
         except Exception as e:
             self._show_error("Main Window Error", f"Cannot show main window: {e}")
@@ -307,11 +402,206 @@ class ApplicationManager(QObject):
     def handle_login_failed(self, message: str):
         self._show_error("Login Failed", message)
 
+    def handle_session_finish_requested(self, reason: str):
+        logger = logging.getLogger(__name__)
+        normalized = (reason or "").strip().lower()
+        self._pending_finish_reason = normalized
+        if normalized.startswith("local"):
+            logger.info("Session finish requested (local)")
+            self._suppress_remote_checks.set()
+        elif normalized.startswith("remote"):
+            logger.info("Session forced remotely (admin)")
+        else:
+            logger.info("Session finish requested (%s)", normalized or "unknown")
+        self._stop_session_heartbeat()
+
+    def _handle_session_finished(self, reason: str) -> None:
+        logger = logging.getLogger(__name__)
+        normalized = (reason or "").strip().lower() or "local_logout"
+        pending = (self._pending_finish_reason or "").strip().lower()
+        if normalized.startswith("remote") and not pending.startswith("remote"):
+            logger.info("Session forced remotely (admin)")
+        if normalized.startswith("local") and not pending.startswith("local"):
+            logger.info("Session finish requested (local)")
+        self.return_to_login(normalized)
+
+    def _finalize_local_session(self, reason: str) -> None:
+        logger = logging.getLogger(__name__)
+        window = self.main_window
+        email = getattr(window, "email", None) or self._current_user_email
+        session_id = getattr(window, "session_id", None) or self._current_session_id
+        if not email or not session_id:
+            return
+
+        status_value = "FORCE_LOGOUT" if reason.startswith("remote") else "LOGOUT"
+        comment = (
+            "Сессия завершена администратором"
+            if reason.startswith("remote")
+            else "Завершение смены"
+        )
+
+        try:
+            db = db_local.LocalDB()
+        except Exception as exc:
+            logger.debug("LocalDB unavailable on finalize: %s", exc)
+            return
+
+        record_id: int | None = None
+        try:
+            with db_local.write_tx() as conn:
+                try:
+                    db.finish_last_status_tx(
+                        conn,
+                        email,
+                        session_id,
+                        reason=status_value,
+                    )
+                except TypeError:
+                    db.finish_last_status_tx(conn, email, session_id)
+
+                if not db.check_existing_logout(email, session_id):
+                    now_iso = dt.datetime.now(dt.UTC).isoformat()
+                    name_value = getattr(window, "name", "") or email
+                    group_value = getattr(window, "group", None)
+                    record_id = db.log_action_tx(
+                        conn=conn,
+                        email=email,
+                        name=name_value,
+                        status=status_value,
+                        action_type="LOGOUT",
+                        comment=comment,
+                        session_id=session_id,
+                        status_start_time=now_iso,
+                        status_end_time=now_iso,
+                        reason=status_value,
+                        user_group=group_value,
+                    )
+        except Exception as exc:
+            logger.warning(
+                "Finalize local session failed (session=%s): %s", session_id, exc
+            )
+            return
+
+        if reason.startswith("remote") and record_id and record_id > 0:
+            try:
+                db.mark_actions_synced([record_id])
+            except Exception as exc:
+                logger.debug("mark_actions_synced failed for %s: %s", record_id, exc)
+
+    def _ack_remote_command_async(self, email: str, session_id: str) -> None:
+        if not hasattr(self.sheets_api, "ack_remote_command"):
+            return
+
+        logger = logging.getLogger(__name__)
+
+        def _worker() -> None:
+            try:
+                ok = self.sheets_api.ack_remote_command(
+                    email=email, session_id=session_id
+                )
+                logger.info("ACK remote command for session %s -> %s", session_id, ok)
+            except Exception as exc:
+                logger.warning(
+                    "Failed to ACK remote command (session=%s, email=%s): %s",
+                    session_id,
+                    email,
+                    exc,
+                )
+
+        threading.Thread(target=_worker, name="remote-ack", daemon=True).start()
+
+    def _show_logout_message(self, reason: str) -> None:
+        reason_key = (reason or "").strip().lower()
+        messages = {
+            "local_logout": "Смена завершена.",
+            "local_logout_offline": "Смена будет завершена при восстановлении сети.",
+            "remote_force_logout": "Сессия завершена администратором.",
+        }
+        message = messages.get(reason_key)
+        if not message:
+            return
+
+        try:
+            if reason_key.startswith("remote"):
+                QMessageBox.warning(None, "Смена", message)
+            else:
+                QMessageBox.information(None, "Смена", message)
+        except (
+            Exception
+        ) as exc:  # pragma: no cover - показ сообщения может не удаться в headless
+            logging.getLogger(__name__).debug("Failed to show logout message: %s", exc)
+
     # --- Общее ---
     def _show_error(self, title: str, message: str):
         QMessageBox.critical(None, title, message)
         logger = logging.getLogger(__name__)
         logger.error("%s: %s", title, message)
+
+    def return_to_login(self, reason: str) -> None:
+        logger = logging.getLogger(__name__)
+        normalized = (reason or "").strip().lower() or "local_logout"
+        if self._returning_to_login:
+            logger.debug(
+                "Return to login already in progress (skip reason=%s)", normalized
+            )
+            return
+
+        self._returning_to_login = True
+        try:
+            logger.info("Return to login (reason=%s)", normalized)
+            self._stop_session_heartbeat()
+            self._finalize_local_session(normalized)
+
+            if (
+                normalized.startswith("remote")
+                and self._current_user_email
+                and self._current_session_id
+            ):
+                self._ack_remote_command_async(
+                    self._current_user_email,
+                    self._current_session_id,
+                )
+
+            self._stop_sync_service()
+
+            try:
+                session_state.set_session_id("")
+                session_state.set_user_email("")
+            except Exception:
+                logger.debug("Unable to reset session state")
+
+            self._pending_finish_reason = None
+            self._suppress_remote_checks.clear()
+
+            if self.main_window:
+                try:
+                    setattr(self.main_window, "_closing_reason", "return_to_login")
+                except Exception:
+                    pass
+                try:
+                    self.main_window.on_logout_callback = None
+                except Exception:
+                    pass
+                try:
+                    self.main_window.close()
+                except Exception as exc:
+                    logger.error("Error on main_window.close(): %s", exc)
+                self.main_window = None
+
+            if self.login_window:
+                try:
+                    self.login_window.close()
+                except Exception as exc:
+                    logger.debug("Error closing login window before restart: %s", exc)
+                self.login_window = None
+
+            self._current_session_id = None
+            self._current_user_email = None
+
+            self.show_login_window()
+            self._show_logout_message(normalized)
+        finally:
+            self._returning_to_login = False
 
     def handle_uncaught_exception(self, exc_type, exc_value, exc_traceback):
         logger = logging.getLogger(__name__)
@@ -346,20 +636,9 @@ class ApplicationManager(QObject):
             self.login_window = None
 
         # останавливаем сервис синхронизации
-        try:
-            if self.sync_worker:
-                try:
-                    self.sync_worker.stop()
-                except Exception:
-                    pass
-            if self.sync_thread and self.sync_thread.isRunning():
-                self.sync_thread.quit()
-                self.sync_thread.wait(2000)
-        finally:
-            from user_app import db_local
-
-            db_local.close_connection()
-            self.app.quit()
+        self._stop_sync_service()
+        db_local.close_connection()
+        self.app.quit()
 
     # точка входа UI
     def run(self):

--- a/user_app/signals.py
+++ b/user_app/signals.py
@@ -11,3 +11,10 @@ class SyncSignals(QObject):
     force_logout = pyqtSignal()
     # Телеметрия синхронизации (обновляется после каждого цикла)
     sync_status_updated = pyqtSignal(dict)
+
+
+class SessionSignals(QObject):
+    """Сигналы жизненного цикла пользовательской сессии."""
+
+    # Причина завершения передаётся строкой (local_logout, remote_force_logout, ...)
+    sessionFinished = pyqtSignal(str)


### PR DESCRIPTION
## Summary
- add session-wide signals and a centralized return_to_login workflow that stops background tasks, finalizes the local DB and re-opens the login screen after any logout reason
- extend the heartbeat loop and UserAPI to detect remote session termination and trigger the unified logout handler
- refactor the employee UI logout flow to run remote calls asynchronously, emit session-finished signals and handle forced logouts without blocking the GUI

## Testing
- ruff check
- black .
- isort .

------
https://chatgpt.com/codex/tasks/task_e_68cd1c541c688327b1d632f61d454d99