### PR TITLE
Unify session lifecycle handling and remote force logout

### DIFF
--- a/auto_sync.py
+++ b/auto_sync.py
@@ -45,8 +45,10 @@ try:
         SYNC_INTERVAL_ONLINE,
         SYNC_RETRY_STRATEGY,
     )
+    from consts import STATUS_ACTIVE, normalize_session_status
     from sheets_api import SheetsAPIError, get_sheets_api
     from user_app.db_local import LocalDB
+    from user_app.signals import SessionSignals
 
     # сохраняем прежнее имя переменной для кода ниже
     sheets_api = get_sheets_api()
@@ -81,7 +83,10 @@ class SyncSignals(QObject):
 
 class SyncManager(QObject):
     def __init__(
-        self, signals: Optional[SyncSignals] = None, background_mode: bool = True
+        self,
+        signals: Optional[SyncSignals] = None,
+        background_mode: bool = True,
+        session_signals: Optional[SessionSignals] = None,
     ):
         super().__init__()
         logger.info(f"Инициализация SyncManager: background_mode={background_mode}")
@@ -89,6 +94,7 @@ class SyncManager(QObject):
         self._db_lock = RLock()
         self._stop_event = Event()
         self.signals = signals
+        self._session_signals = session_signals
         self._background_mode = background_mode
         self._sync_interval = SYNC_INTERVAL if background_mode else 0
         self._last_sync_time = None
@@ -129,63 +135,85 @@ class SyncManager(QObject):
             return
 
         try:
+            status = self._check_user_session_status(email, session_id)
             logger.info(
-                f"Проверка статуса сессии для пользователя {email}, session_id: {session_id}"
+                "Проверка статуса сессии для пользователя %s, session_id=%s -> %s",
+                email,
+                session_id,
+                status or "<unknown>",
             )
-            # Проверяем статус сессии
-            remote_status = self._check_user_session_status(email, session_id)
-            logger.debug(f"Получен удаленный статус: {remote_status}")
 
-            if remote_status == "kicked":
-                logger.info(
-                    f"[ADMIN_LOGOUT] Обнаружен статус 'kicked' для пользователя {email}. Испускаем force_logout."
-                )
-                if self.signals:
-                    self.signals.force_logout.emit()
-                # Отправляем ACK подтверждение команды
-                try:
-                    sheets_api.ack_remote_command(email=email, session_id=session_id)
-                    logger.info(f"ACK отправлен для команды kick пользователя {email}")
-                except Exception as ack_error:
-                    logger.error(f"Ошибка отправки ACK: {ack_error}")
-                return
-            elif remote_status == "finished":
-                logger.warning(
-                    f"Получена команда 'finished' для пользователя {email}. Отправка сигнала в GUI."
-                )
-                if self.signals:
-                    logger.info("Emit force_logout signal to GUI")
-                    self.signals.force_logout.emit()
-                # Отправляем ACK подтверждение команды
-                try:
-                    sheets_api.ack_remote_command(email=email, session_id=session_id)
-                    logger.info(
-                        f"ACK отправлен для команды finished пользователя {email}"
-                    )
-                except Exception as ack_error:
-                    logger.error(f"Ошибка отправки ACK: {ack_error}")
-                # НЕ вызываем self.stop() здесь!
+            if status and status != STATUS_ACTIVE:
+                self._emit_remote_logout(email, session_id, status)
             else:
-                logger.debug(f"Статус сессии в норме: {remote_status}")
+                logger.debug(f"Статус сессии в норме: {status}")
 
         except Exception as e:
             logger.error(
                 f"Ошибка при проверке удаленных команд для {email}: {e}", exc_info=True
             )
 
-    def _check_user_session_status(self, email: str, session_id: str) -> str:
+    def _emit_remote_logout(self, email: str, session_id: str, status: str) -> None:
+        logger.info(
+            "[ADMIN_LOGOUT] Обнаружен статус '%s' для пользователя %s. Запускаем завершение сессии.",
+            status,
+            email,
+        )
+        ack_required = True
+        if self._session_signals:
+            try:
+                self._session_signals.sessionFinished.emit("remote_force_logout")
+                ack_required = False
+            except Exception as exc:
+                logger.debug("sessionFinished emit failed: %s", exc)
+        elif self.signals:
+            try:
+                self.signals.force_logout.emit()
+                ack_required = False
+            except Exception as exc:
+                logger.debug("force_logout emit failed: %s", exc)
+
+        if ack_required:
+            self._ack_remote_command(email, session_id)
+
+    def _ack_remote_command(self, email: str | None, session_id: str | None) -> None:
+        if not hasattr(sheets_api, "ack_remote_command"):
+            return
+
+        email_value = (email or "").strip()
+        session_value = str(session_id or "").strip()
+        if not email_value or not session_value:
+            return
+
+        try:
+            ok = sheets_api.ack_remote_command(
+                email=email_value, session_id=session_value
+            )
+            logger.info(
+                "Remote command ACK (sync manager) email=%s session=%s -> %s",
+                email_value,
+                session_value,
+                ok,
+            )
+        except Exception as exc:
+            logger.warning(
+                "Failed to ACK remote command (email=%s, session=%s): %s",
+                email_value,
+                session_value,
+                exc,
+            )
+
+    def _check_user_session_status(self, email: str, session_id: str) -> str | None:
         """
-        Возвращает строковый статус из ActiveSessions:
-        'active' | 'kicked' | 'finished' | 'expired' | 'unknown'
+        Возвращает нормализованный статус из ActiveSessions:
+        'В работе' | 'LOGOUT' | 'FORCE_LOGOUT'
         """
         try:
-            row = sheets_api.check_user_session_status(email, session_id)
-            if not row:
-                return "unknown"
-            return (row.get("Status") or "unknown").strip().lower()
+            status = sheets_api.check_user_session_status(email, session_id)
+            return normalize_session_status(status)
         except Exception as e:
             logger.error(f"Ошибка при проверке статуса сессии: {e}")
-            return "unknown"
+            return None
 
     def _ping_listener(self):
         logger.info(f"Запуск ping listener на UDP порту {PING_PORT}")

--- a/config.py
+++ b/config.py
@@ -31,6 +31,16 @@ def _read_env_int(var_name: str, default: int) -> int:
 HEARTBEAT_PERIOD_SEC = _read_env_int("HEARTBEAT_PERIOD_SEC", 60)
 STALE_SESSION_MINUTES = _read_env_int("STALE_SESSION_MINUTES", 15)
 
+
+def _read_env_bool(var_name: str, default: bool = False) -> bool:
+    raw = os.getenv(var_name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in {"1", "true", "yes", "on"}
+
+
+DEBUG_IDS: bool = _read_env_bool("DEBUG_IDS", False)
+
 # ==================== Импорт для работы с зашифрованным credentials ====================
 import pyzipper
 

--- a/consts.py
+++ b/consts.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import re
+from typing import Optional
+
+STATUS_ACTIVE: str = "В работе"
+STATUS_LOGOUT: str = "LOGOUT"
+STATUS_FORCE_LOGOUT: str = "FORCE_LOGOUT"
+
+
+def _canonical_key(value: str) -> str:
+    """Normalize status strings for alias lookup."""
+    return re.sub(r"[\s_-]+", " ", value.strip().lower())
+
+
+_ALIAS_MAP: dict[str, str] = {
+    _canonical_key("active"): STATUS_ACTIVE,
+    _canonical_key("в работе"): STATUS_ACTIVE,
+    _canonical_key("finished"): STATUS_LOGOUT,
+    _canonical_key("logout"): STATUS_LOGOUT,
+    _canonical_key("logoff"): STATUS_LOGOUT,
+    _canonical_key("force_logout"): STATUS_FORCE_LOGOUT,
+    _canonical_key("force logout"): STATUS_FORCE_LOGOUT,
+    _canonical_key("kicked"): STATUS_FORCE_LOGOUT,
+}
+
+
+def normalize_session_status(raw: Optional[str]) -> Optional[str]:
+    """Return canonical session status value for comparisons."""
+    if raw is None:
+        return None
+    text = str(raw).strip()
+    if not text:
+        return None
+    if text in {STATUS_ACTIVE, STATUS_LOGOUT, STATUS_FORCE_LOGOUT}:
+        return text
+    upper = text.upper()
+    if upper == STATUS_FORCE_LOGOUT:
+        return STATUS_FORCE_LOGOUT
+    if upper == STATUS_LOGOUT:
+        return STATUS_LOGOUT
+    key = _canonical_key(text)
+    if key in _ALIAS_MAP:
+        return _ALIAS_MAP[key]
+    if "force logout" in key or "kicked" in key:
+        return STATUS_FORCE_LOGOUT
+    if "finished" in key or "logout" in key:
+        return STATUS_LOGOUT
+    if "active" in key or "в работе" in key:
+        return STATUS_ACTIVE
+    return text
+
+
+__all__ = [
+    "STATUS_ACTIVE",
+    "STATUS_LOGOUT",
+    "STATUS_FORCE_LOGOUT",
+    "normalize_session_status",
+]

--- a/logging_setup.py
+++ b/logging_setup.py
@@ -13,10 +13,17 @@ from typing import Optional, Union
 _LOGGING_INITIALIZED = False
 _ROOT_LOGGER_CONFIGURED = False
 
+try:  # pragma: no cover - защитный импорт
+    from config import DEBUG_IDS as _DEBUG_IDS  # type: ignore
+except Exception:  # pragma: no cover - fallback на окружение
+    _DEBUG_IDS = os.getenv("DEBUG_IDS", "").strip().lower() in {"1", "true", "yes", "on"}
+
 
 # ----------------------------- PII masking -----------------------------------
 def _mask_pii(msg: str) -> str:
     """Грубое маскирование email и телефонов в логах."""
+    if _DEBUG_IDS:
+        return msg
     msg = re.sub(r"([A-Za-z0-9._%+-]+)@([A-Za-z0-9.-]+\.[A-Za-z]{2,})", r"***@\2", msg)
     msg = re.sub(r"\+?\d[\d\s\-()]{6,}\d", "***PHONE***", msg)
     return msg

--- a/logging_setup.py
+++ b/logging_setup.py
@@ -16,7 +16,12 @@ _ROOT_LOGGER_CONFIGURED = False
 try:  # pragma: no cover - защитный импорт
     from config import DEBUG_IDS as _DEBUG_IDS  # type: ignore
 except Exception:  # pragma: no cover - fallback на окружение
-    _DEBUG_IDS = os.getenv("DEBUG_IDS", "").strip().lower() in {"1", "true", "yes", "on"}
+    _DEBUG_IDS = os.getenv("DEBUG_IDS", "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
 
 
 # ----------------------------- PII masking -----------------------------------

--- a/sheets_api.py
+++ b/sheets_api.py
@@ -19,6 +19,8 @@ import gspread
 from google.auth.transport.requests import AuthorizedSession
 from google.oauth2.service_account import Credentials
 
+from consts import normalize_session_status
+
 logger = logging.getLogger(
     "sheets_api"
 )  # никаких handlers здесь — конфиг только в приложении
@@ -1156,18 +1158,49 @@ class SheetsAPI:
             return False
 
     def check_user_session_status(self, email: str, session_id: str) -> str | None:
-        """Возвращает статус ('active'/'finished'/'kicked'/...) или None."""
+        """Возвращает нормализованный статус сессии или None."""
+
         from config import ACTIVE_SESSIONS_SHEET
+
+        sid = str(session_id or "").strip()
+        if not sid:
+            return None
 
         ws = self._get_ws(ACTIVE_SESSIONS_SHEET)
         table = self._read_table(ws)
         em = (email or "").strip().lower()
-        sid = str(session_id or "").strip()
-        for r in table:
-            if (r.get("Email", "") or "").strip().lower() == em and str(
-                r.get("SessionID", "")
-            ).strip() == sid:
-                return (r.get("Status") or "").strip().lower()
+        fallback_row: dict[str, Any] | None = None
+        fallback_row_idx: int | None = None
+
+        for row_idx, row in enumerate(table, start=2):
+            row_sid = str(row.get("SessionID", "") or "").strip()
+            if row_sid == sid:
+                status_value = normalize_session_status(row.get("Status"))
+                logger.info(
+                    "ActiveSessions status for session=%s -> %s",
+                    sid,
+                    status_value or "<unknown>",
+                )
+                return status_value
+            if (
+                em
+                and (row.get("Email", "") or "").strip().lower() == em
+            ):
+                fallback_row = row
+                fallback_row_idx = row_idx
+
+        if fallback_row:
+            status_value = normalize_session_status(fallback_row.get("Status"))
+            logger.info(
+                "ActiveSessions status for session=%s (email=%s row=%s) -> %s",
+                sid,
+                em or "<unknown>",
+                fallback_row_idx if fallback_row_idx is not None else "<unknown>",
+                status_value or "<unknown>",
+            )
+            return status_value
+
+        logger.info("ActiveSessions status for session=%s -> not found", sid)
         return None
 
     def ack_remote_command(self, email: str, session_id: str) -> bool:

--- a/sheets_api.py
+++ b/sheets_api.py
@@ -1182,10 +1182,7 @@ class SheetsAPI:
                     status_value or "<unknown>",
                 )
                 return status_value
-            if (
-                em
-                and (row.get("Email", "") or "").strip().lower() == em
-            ):
+            if em and (row.get("Email", "") or "").strip().lower() == em:
                 fallback_row = row
                 fallback_row_idx = row_idx
 

--- a/user_app/api.py
+++ b/user_app/api.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 
 import datetime as dt
 import logging
-import uuid
 
+from consts import STATUS_FORCE_LOGOUT, STATUS_LOGOUT, normalize_session_status
 from sheets_api import SheetsAPI, SheetsAPIError
+from user_app.session import generate_session_id
 
 logger = logging.getLogger(__name__)
 
@@ -36,7 +37,7 @@ class UserAPI:
         Создаёт запись в ActiveSessions (Status=active).
         Возвращает session_id.
         """
-        session_id = str(uuid.uuid4())
+        session_id = generate_session_id(email)
         self.sheets.set_active_session(
             email=email,
             name=name,
@@ -66,10 +67,15 @@ class UserAPI:
         """
         Пулинг статуса: если админ принудительно разлогинил (Status=kicked) — вернём True.
         """
-        st = self.sheets.check_user_session_status(email=email, session_id=session_id)
-        return st in ("kicked", "finished")
+        status = self.sheets.check_user_session_status(
+            email=email, session_id=session_id
+        )
+        normalized = normalize_session_status(status)
+        return normalized in {STATUS_FORCE_LOGOUT, STATUS_LOGOUT}
 
-    def get_session_status(self, email: str, session_id: str) -> str | None:
+    def get_session_status(
+        self, session_id: str, email: str | None = None
+    ) -> str | None:
         try:
             return self.sheets.check_user_session_status(
                 email=email, session_id=session_id

--- a/user_app/db_local.py
+++ b/user_app/db_local.py
@@ -10,8 +10,11 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
 
+from consts import STATUS_ACTIVE, STATUS_FORCE_LOGOUT, STATUS_LOGOUT
 from config import LOCAL_DB_PATH, MAX_COMMENT_LENGTH, MAX_HISTORY_DAYS
+from user_app import session as session_state
 from user_app.db_migrations import apply_migrations
+from user_app.session import generate_session_id
 
 logger = logging.getLogger(__name__)
 
@@ -25,6 +28,101 @@ _BUSY_MS = 60000  # до 60с ждём блокировку
 
 class LocalDBError(Exception):
     """Ошибки локальной БД."""
+
+
+def _ensure_iso_utc(value: dt.datetime | str | None) -> str:
+    if isinstance(value, dt.datetime):
+        moment = value if value.tzinfo else value.replace(tzinfo=dt.UTC)
+        return moment.astimezone(dt.UTC).isoformat()
+    if value:
+        return str(value)
+    return dt.datetime.now(dt.UTC).isoformat()
+
+
+def _resolve_email_tx(
+    conn: sqlite3.Connection, session_id: str, email: str | None = None
+) -> str:
+    candidate = (email or "").strip()
+    if candidate:
+        return candidate
+    state_email = (session_state.get_user_email() or "").strip()
+    if state_email:
+        return state_email
+    cur = conn.cursor()
+    try:
+        cur.execute(
+            """
+            SELECT email
+              FROM logs
+             WHERE session_id=?
+          ORDER BY id DESC
+             LIMIT 1
+            """,
+            (session_id,),
+        )
+        row = cur.fetchone()
+        if row and row[0]:
+            return str(row[0]).strip()
+    finally:
+        cur.close()
+    return ""
+
+
+def _resolve_name_tx(
+    conn: sqlite3.Connection,
+    email: str,
+    session_id: str,
+    name: str | None = None,
+) -> str:
+    if name and name.strip():
+        return name.strip()
+    cur = conn.cursor()
+    try:
+        cur.execute(
+            """
+            SELECT name
+              FROM logs
+             WHERE email=? AND session_id=?
+          ORDER BY id DESC
+             LIMIT 1
+            """,
+            (email, session_id),
+        )
+        row = cur.fetchone()
+        if row and row[0]:
+            return str(row[0]).strip()
+    finally:
+        cur.close()
+    return email
+
+
+def _resolve_group_tx(
+    conn: sqlite3.Connection,
+    email: str,
+    session_id: str,
+    user_group: str | None = None,
+) -> str | None:
+    if user_group and user_group.strip():
+        return user_group.strip()
+    cur = conn.cursor()
+    try:
+        cur.execute(
+            """
+            SELECT user_group
+              FROM logs
+             WHERE email=? AND session_id=?
+          ORDER BY id DESC
+             LIMIT 1
+            """,
+            (email, session_id),
+        )
+        row = cur.fetchone()
+        if row and row[0]:
+            value = str(row[0]).strip()
+            return value or None
+    finally:
+        cur.close()
+    return None
 
 
 def _connect(path: str) -> sqlite3.Connection:
@@ -579,7 +677,7 @@ class LocalDB:
     # Action logs (то, что синхронизируется)
     # ------------------------------------------------------------------ #
     def _gen_session_id(self, email: str) -> str:
-        return f"{(email or '')[:8]}_{dt.datetime.now().strftime('%Y%m%d%H%M%S')}"
+        return generate_session_id(email)
 
     def log_action(
         self,
@@ -713,6 +811,282 @@ class LocalDB:
                 )
                 return -1
             raise LocalDBError(f"Ошибка записи в лог: {e}") from e
+
+    def mark_session_active(
+        self,
+        session_id: str,
+        *,
+        email: str | None = None,
+        name: str | None = None,
+        status: str = STATUS_ACTIVE,
+        started_at: dt.datetime | str | None = None,
+        comment: str | None = None,
+        user_group: str | None = None,
+    ) -> tuple[int | None, bool]:
+        """Зафиксировать начало смены, идемпотентно по session_id."""
+
+        self._ensure_open()
+        if self.conn is None:
+            raise LocalDBError("Не удалось открыть локальную БД")
+
+        with self._lock:
+            with write_tx() as conn:
+                return self.mark_session_active_tx(
+                    conn,
+                    session_id=session_id,
+                    email=email,
+                    name=name,
+                    status=status,
+                    started_at=started_at,
+                    comment=comment,
+                    user_group=user_group,
+                )
+
+    def mark_session_active_tx(
+        self,
+        conn: sqlite3.Connection,
+        *,
+        session_id: str,
+        email: str | None = None,
+        name: str | None = None,
+        status: str = STATUS_ACTIVE,
+        started_at: dt.datetime | str | None = None,
+        comment: str | None = None,
+        user_group: str | None = None,
+    ) -> tuple[int | None, bool]:
+        sid = (session_id or "").strip()
+        if not sid:
+            return None, False
+
+        email_value = _resolve_email_tx(conn, sid, email)
+        if not email_value:
+            return None, False
+
+        name_value = _resolve_name_tx(conn, email_value, sid, name)
+        group_value = _resolve_group_tx(conn, email_value, sid, user_group)
+        start_iso = _ensure_iso_utc(started_at)
+        comment_value = (comment or "Начало смены").strip()
+
+        cur = conn.cursor()
+        try:
+            cur.execute(
+                """
+                SELECT id
+                  FROM logs
+                 WHERE email=?
+                   AND session_id=?
+                   AND LOWER(action_type)='login'
+              ORDER BY id DESC
+                 LIMIT 1
+                """,
+                (email_value, sid),
+            )
+            row = cur.fetchone()
+            if row:
+                rid = int(row[0])
+                cur.execute(
+                    """
+                    UPDATE logs
+                       SET status=?,
+                           status_start_time=COALESCE(status_start_time, ?),
+                           status_end_time=NULL,
+                           comment=CASE
+                               WHEN ? != '' AND (comment IS NULL OR comment='') THEN ?
+                               ELSE comment
+                           END,
+                           user_group=CASE
+                               WHEN ? IS NOT NULL AND ? != '' AND (user_group IS NULL OR user_group='')
+                                   THEN ?
+                               ELSE user_group
+                           END
+                     WHERE id=?
+                    """,
+                    (
+                        status,
+                        start_iso,
+                        comment_value,
+                        comment_value,
+                        group_value,
+                        group_value or "",
+                        group_value,
+                        rid,
+                    ),
+                )
+                return rid, False
+
+            record_id = self.log_action_tx(
+                conn=conn,
+                email=email_value,
+                name=name_value,
+                status=status,
+                action_type="LOGIN",
+                comment=comment_value,
+                session_id=sid,
+                status_start_time=start_iso,
+                status_end_time=None,
+                reason=None,
+                user_group=group_value,
+            )
+            return record_id, True
+        finally:
+            cur.close()
+
+    def finish_session(
+        self,
+        session_id: str,
+        *,
+        email: str | None = None,
+        name: str | None = None,
+        status: str = STATUS_LOGOUT,
+        comment: str | None = None,
+        reason: str | None = None,
+        logout_time: dt.datetime | str | None = None,
+        user_group: str | None = None,
+    ) -> tuple[int | None, bool]:
+        """Закрыть сессию (LOGOUT/FORCE_LOGOUT) без дублирования записей."""
+
+        self._ensure_open()
+        if self.conn is None:
+            raise LocalDBError("Не удалось открыть локальную БД")
+
+        with self._lock:
+            with write_tx() as conn:
+                return self.finish_session_tx(
+                    conn,
+                    session_id=session_id,
+                    email=email,
+                    name=name,
+                    status=status,
+                    comment=comment,
+                    reason=reason,
+                    logout_time=logout_time,
+                    user_group=user_group,
+                )
+
+    def finish_session_tx(
+        self,
+        conn: sqlite3.Connection,
+        *,
+        session_id: str,
+        email: str | None = None,
+        name: str | None = None,
+        status: str = STATUS_LOGOUT,
+        comment: str | None = None,
+        reason: str | None = None,
+        logout_time: dt.datetime | str | None = None,
+        user_group: str | None = None,
+    ) -> tuple[int | None, bool]:
+        sid = (session_id or "").strip()
+        if not sid:
+            return None, False
+
+        email_value = _resolve_email_tx(conn, sid, email)
+        if not email_value:
+            return None, False
+
+        name_value = _resolve_name_tx(conn, email_value, sid, name)
+        group_value = _resolve_group_tx(conn, email_value, sid, user_group)
+        logout_iso = _ensure_iso_utc(logout_time)
+        status_value = (status or STATUS_LOGOUT).strip() or STATUS_LOGOUT
+        reason_value = (reason or status_value).strip()
+        comment_value = (comment or "").strip()
+
+        cur = conn.cursor()
+        try:
+            cur.execute(
+                """
+                UPDATE logs
+                   SET status_end_time = COALESCE(status_end_time, ?)
+                 WHERE email=?
+                   AND session_id=?
+                   AND status_end_time IS NULL
+                   AND action_type IN ('LOGIN','STATUS_CHANGE')
+                """,
+                (logout_iso, email_value, sid),
+            )
+            if reason_value:
+                cur.execute(
+                    """
+                    UPDATE logs
+                       SET reason = CASE
+                           WHEN reason IS NULL OR reason='' THEN ?
+                           ELSE reason
+                       END
+                     WHERE email=?
+                       AND session_id=?
+                       AND action_type IN ('LOGIN','STATUS_CHANGE')
+                    """,
+                    (reason_value, email_value, sid),
+                )
+
+            cur.execute(
+                """
+                SELECT id
+                  FROM logs
+                 WHERE email=?
+                   AND session_id=?
+                   AND LOWER(action_type)='logout'
+              ORDER BY id DESC
+                 LIMIT 1
+                """,
+                (email_value, sid),
+            )
+            row = cur.fetchone()
+            if row:
+                rid = int(row[0])
+                cur.execute(
+                    """
+                    UPDATE logs
+                       SET status=?,
+                           status_start_time=COALESCE(status_start_time, ?),
+                           status_end_time=COALESCE(status_end_time, ?),
+                           reason=CASE
+                               WHEN ? != '' THEN COALESCE(NULLIF(reason,''), ?)
+                               ELSE reason
+                           END,
+                           comment=CASE
+                               WHEN ? != '' AND (comment IS NULL OR comment='') THEN ?
+                               ELSE comment
+                           END,
+                           user_group=CASE
+                               WHEN ? IS NOT NULL AND ? != '' AND (user_group IS NULL OR user_group='')
+                                   THEN ?
+                               ELSE user_group
+                           END
+                     WHERE id=?
+                    """,
+                    (
+                        status_value,
+                        logout_iso,
+                        logout_iso,
+                        reason_value,
+                        reason_value,
+                        comment_value,
+                        comment_value,
+                        group_value,
+                        group_value or "",
+                        group_value,
+                        rid,
+                    ),
+                )
+                return rid, False
+
+            record_id = self.log_action_tx(
+                conn=conn,
+                email=email_value,
+                name=name_value,
+                status=status_value,
+                action_type="LOGOUT",
+                comment=comment_value or None,
+                session_id=sid,
+                status_start_time=logout_iso,
+                status_end_time=logout_iso,
+                reason=reason_value or None,
+                user_group=group_value,
+            )
+            return record_id, True
+        finally:
+            cur.close()
 
     def get_unsynced_actions(self, limit: int = 100) -> list[tuple]:
         self._ensure_open()

--- a/user_app/db_local.py
+++ b/user_app/db_local.py
@@ -10,8 +10,8 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
 
-from consts import STATUS_ACTIVE, STATUS_FORCE_LOGOUT, STATUS_LOGOUT
 from config import LOCAL_DB_PATH, MAX_COMMENT_LENGTH, MAX_HISTORY_DAYS
+from consts import STATUS_ACTIVE, STATUS_LOGOUT
 from user_app import session as session_state
 from user_app.db_migrations import apply_migrations
 from user_app.session import generate_session_id

--- a/user_app/gui.py
+++ b/user_app/gui.py
@@ -12,11 +12,16 @@ PROJECT_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(PROJECT_ROOT))
 
 from config import MAX_COMMENT_LENGTH, STATUS_GROUPS
-from consts import STATUS_ACTIVE, STATUS_FORCE_LOGOUT, STATUS_LOGOUT, normalize_session_status
+from consts import (
+    STATUS_ACTIVE,
+    STATUS_FORCE_LOGOUT,
+    STATUS_LOGOUT,
+    normalize_session_status,
+)
 from sheets_api import SheetsAPIError, get_sheets_api
+from user_app import session as session_state
 from user_app.db_local import LocalDB, LocalDBError, write_tx
 from user_app.signals import SessionSignals
-from user_app import session as session_state
 
 try:
     from sync.notifications import Notifier
@@ -409,8 +414,12 @@ class EmployeeApp(QWidget):
                     user_group=self.group or None,
                 )
                 if created and record_id and record_id > 0:
-                    self._send_action_to_sheets(record_id, user_group=self.group or None)
-                self.shift_start_time = self._get_local_session_start(self.shift_start_time)
+                    self._send_action_to_sheets(
+                        record_id, user_group=self.group or None
+                    )
+                self.shift_start_time = self._get_local_session_start(
+                    self.shift_start_time
+                )
                 self.status_start_time = datetime.now()
         except LocalDBError as e:
             logger.error(f"Ошибка инициализации БД: {e}")
@@ -521,9 +530,7 @@ class EmployeeApp(QWidget):
         """
         try:
             status = normalize_session_status(
-                self.sheets_api.check_user_session_status(
-                    self.email, self.session_id
-                )
+                self.sheets_api.check_user_session_status(self.email, self.session_id)
             )
             if status:
                 logger.debug(

--- a/user_app/gui.py
+++ b/user_app/gui.py
@@ -4,7 +4,7 @@ import logging
 import sys
 import threading
 import time
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Callable, Optional
 
@@ -12,9 +12,11 @@ PROJECT_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(PROJECT_ROOT))
 
 from config import MAX_COMMENT_LENGTH, STATUS_GROUPS
+from consts import STATUS_ACTIVE, STATUS_FORCE_LOGOUT, STATUS_LOGOUT, normalize_session_status
 from sheets_api import SheetsAPIError, get_sheets_api
 from user_app.db_local import LocalDB, LocalDBError, write_tx
 from user_app.signals import SessionSignals
+from user_app import session as session_state
 
 try:
     from sync.notifications import Notifier
@@ -58,6 +60,7 @@ class EmployeeApp(QWidget):
         login_was_performed: bool = True,
         session_signals: Optional[SessionSignals] = None,
         on_session_finish_requested: Optional[Callable[[str], None]] = None,
+        session_started_at: Optional[str] = None,
     ):
         super().__init__()
         self.email = email
@@ -70,9 +73,10 @@ class EmployeeApp(QWidget):
         self.session_signals = session_signals
         self.on_session_finish_requested = on_session_finish_requested
 
-        self.current_status = "В работе"
-        self.status_start_time = datetime.now()
-        self.shift_start_time = datetime.now()
+        now_local = datetime.now()
+        self.current_status = STATUS_ACTIVE
+        self.status_start_time = now_local
+        self.shift_start_time = now_local
         self.last_sync_time = None
         self.shift_ended = False
         self._logout_in_progress = False
@@ -80,12 +84,18 @@ class EmployeeApp(QWidget):
         # Логика закрытия: None, "admin_logout", "user_close", "auto_logout"
         self._closing_reason = "user_close"  # по умолчанию
 
+        self._session_started_at = session_started_at
+        self.shift_start_time = self._get_local_session_start(self.shift_start_time)
         if session_id is not None:
             self.session_id = session_id
             self._continue_existing_session = True
         else:
-            self.session_id = self._generate_session_id()
+            self.session_id = session_state.generate_session_id(self.email)
             self._continue_existing_session = False
+            try:
+                session_state.set_session_id(self.session_id)
+            except Exception:
+                logger.debug("Unable to persist generated session id")
         self.status_buttons = {}
 
         self.login_was_performed = login_was_performed
@@ -108,9 +118,6 @@ class EmployeeApp(QWidget):
             "Group": self.group,
         }
 
-    def _generate_session_id(self) -> str:
-        return f"{self.email[:8]}_{datetime.now().strftime('%Y%m%d%H%M%S')}"
-
     def _make_action_payload_from_row(self, row):
         # Порядок столбцов в logs:
         # 0:id 1:session_id 2:email 3:name 4:status 5:action_type 6:comment
@@ -128,6 +135,42 @@ class EmployeeApp(QWidget):
             "status_end_time": row[13],
             "reason": row[14] if len(row) > 14 else None,
         }
+
+    def _get_local_session_start(self, fallback: Optional[datetime] = None) -> datetime:
+        """Convert stored session start to local naive datetime for timers."""
+
+        fallback_dt = fallback or datetime.now()
+        raw_value = self._session_started_at
+        candidate: Optional[datetime]
+
+        if isinstance(raw_value, datetime):
+            candidate = raw_value
+        elif isinstance(raw_value, str):
+            raw_text = raw_value.strip()
+            if not raw_text:
+                return fallback_dt
+            try:
+                candidate = datetime.fromisoformat(raw_text)
+            except ValueError:
+                logger.debug("Invalid session start format: %s", raw_value)
+                return fallback_dt
+        else:
+            return fallback_dt
+
+        if candidate.tzinfo is not None:
+            try:
+                candidate = candidate.astimezone()
+            except Exception as exc:
+                logger.debug("Failed to convert session start timezone: %s", exc)
+                try:
+                    candidate = candidate.astimezone(timezone.utc)
+                except Exception:
+                    return fallback_dt
+
+        try:
+            return candidate.replace(tzinfo=None)
+        except Exception:
+            return fallback_dt
 
     def _send_action_to_sheets(self, record_id, user_group=None):
         threading.Thread(
@@ -173,8 +216,12 @@ class EmployeeApp(QWidget):
             )
 
     def _finish_and_send_previous_status(self):
-        prev_id = self.db.finish_last_status(self.email, self.session_id)
-        if prev_id:
+        prev_result = self.db.finish_last_status(self.email, self.session_id)
+        if isinstance(prev_result, tuple):
+            prev_id = prev_result[0]
+        else:
+            prev_id = prev_result
+        if prev_id and prev_id > 0:
             threading.Thread(
                 target=self._finish_and_send_previous_status_worker,
                 args=(prev_id,),
@@ -288,17 +335,11 @@ class EmployeeApp(QWidget):
                     )
                     return True, False
 
-                status = (
-                    (
-                        self.sheets_api.check_user_session_status(
-                            self.email, self.session_id
-                        )
-                        or ""
-                    )
-                    .strip()
-                    .lower()
+                raw_status = self.sheets_api.check_user_session_status(
+                    self.email, self.session_id
                 )
-                if status and status != "active":
+                status = normalize_session_status(raw_status)
+                if status and status != STATUS_ACTIVE:
                     logger.info(
                         "finish_active_session skipped: remote status %s for %s",
                         status,
@@ -351,28 +392,26 @@ class EmployeeApp(QWidget):
         try:
             self.db = LocalDB()
             if self.login_was_performed:
-                now = datetime.now().isoformat()
-                # Определяем тип действия: LOGIN только если это новая сессия
-                has_session = bool(self._continue_existing_session)
-                action_type = "STATUS_CHANGE" if has_session else "LOGIN"
-                comment = "Начало смены" if action_type == "LOGIN" else "Смена статуса"
+                if self._session_started_at:
+                    started_at_arg: datetime | str = self._session_started_at
+                else:
+                    started_dt = datetime.now(timezone.utc)
+                    started_at_arg = started_dt
+                    self._session_started_at = started_dt.isoformat()
 
-                # Используем сериализованную транзакцию для записи
-                with write_tx() as conn:
-                    record_id = self.db.log_action_tx(
-                        conn=conn,
-                        email=self.email,
-                        name=self.name,
-                        status=self.current_status,
-                        action_type=action_type,
-                        comment=comment,
-                        session_id=self.session_id,
-                        status_start_time=now,
-                        status_end_time=None,
-                        reason=None,
-                    )
-                self.status_start_time = datetime.fromisoformat(now)
-                self._send_action_to_sheets(record_id)
+                record_id, created = self.db.mark_session_active(
+                    self.session_id,
+                    email=self.email,
+                    name=self.name,
+                    status=STATUS_ACTIVE,
+                    started_at=started_at_arg,
+                    comment="Начало смены",
+                    user_group=self.group or None,
+                )
+                if created and record_id and record_id > 0:
+                    self._send_action_to_sheets(record_id, user_group=self.group or None)
+                self.shift_start_time = self._get_local_session_start(self.shift_start_time)
+                self.status_start_time = datetime.now()
         except LocalDBError as e:
             logger.error(f"Ошибка инициализации БД: {e}")
             QMessageBox.critical(
@@ -481,18 +520,19 @@ class EmployeeApp(QWidget):
         True — если по (email, session_id) в ActiveSessions статус 'finished', 'kicked' или 'force_logout'.
         """
         try:
-            status = self.sheets_api.check_user_session_status(
-                self.email, self.session_id
-            )
-            if isinstance(status, dict):
-                st = (status.get("Status") or "").strip().lower()
-            else:
-                st = str(status or "").strip().lower()
-            if st:
-                logger.debug(
-                    f"[ACTIVESESSIONS] status for {self.email}/{self.session_id}: {st}"
+            status = normalize_session_status(
+                self.sheets_api.check_user_session_status(
+                    self.email, self.session_id
                 )
-            return st in {"finished", "kicked", "force_logout"}
+            )
+            if status:
+                logger.debug(
+                    "[ACTIVESESSIONS] status for %s/%s: %s",
+                    self.email,
+                    self.session_id,
+                    status,
+                )
+            return status in {STATUS_LOGOUT, STATUS_FORCE_LOGOUT}
         except Exception as e:
             logger.debug(f"_is_session_finished_remote error: {e}")
         return False
@@ -546,7 +586,7 @@ class EmployeeApp(QWidget):
         try:
             record_id = self._log_shift_end(
                 "Сессия завершена администратором",
-                reason="FORCE_LOGOUT",
+                reason=STATUS_FORCE_LOGOUT,
                 sync_to_sheets=False,
             )
         except Exception as exc:
@@ -694,39 +734,24 @@ class EmployeeApp(QWidget):
     def _log_shift_end(
         self, comment: str, reason: str = "LOGOUT", sync_to_sheets: bool = True
     ) -> int:
-        now = datetime.now().isoformat()
-        status_value = reason or "LOGOUT"
+        status_value = reason or STATUS_LOGOUT
         record_id = -1
         try:
-            with write_tx() as conn:
-                # Завершаем последний статус
-                try:
-                    self.db.finish_last_status_tx(
-                        conn, self.email, self.session_id, now, reason=status_value
-                    )
-                except TypeError:
-                    self.db.finish_last_status_tx(
-                        conn, self.email, self.session_id, now
-                    )
-
-                # Логируем завершение смены
-                record_id = self.db.log_action_tx(
-                    conn=conn,
-                    email=self.email,
-                    name=self.name,
-                    status=status_value,
-                    action_type="LOGOUT",
-                    comment=comment,
-                    session_id=self.session_id,
-                    status_start_time=now,
-                    status_end_time=now,
-                    reason=status_value,
-                    user_group=self.group,
-                )
+            logout_moment = datetime.now(timezone.utc)
+            record_id, created = self.db.finish_session(
+                self.session_id,
+                email=self.email,
+                name=self.name,
+                status=status_value,
+                comment=comment,
+                reason=status_value,
+                logout_time=logout_moment,
+                user_group=self.group or None,
+            )
             if record_id and record_id > 0:
-                if sync_to_sheets:
+                if sync_to_sheets and created:
                     self._send_action_to_sheets(record_id, user_group=self.group)
-                else:
+                elif not sync_to_sheets:
                     try:
                         self.db.mark_actions_synced([record_id])
                     except Exception as sync_exc:
@@ -735,7 +760,7 @@ class EmployeeApp(QWidget):
                             record_id,
                             sync_exc,
                         )
-            return record_id
+            return record_id if record_id is not None else -1
         except Exception as e:
             logger.error(f"Ошибка записи завершения смены: {e}")
             raise
@@ -754,7 +779,7 @@ class EmployeeApp(QWidget):
         self._notify_session_finish_requested("local_logout")
 
         try:
-            self._log_shift_end(comment, reason="LOGOUT", sync_to_sheets=True)
+            self._log_shift_end(comment, reason=STATUS_LOGOUT, sync_to_sheets=True)
         except Exception:
             self._logout_in_progress = False
             self._closing_reason = "user_close"

--- a/user_app/login_window.py
+++ b/user_app/login_window.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import datetime as dt
 import logging
 import re
 import sys
@@ -34,6 +35,8 @@ except ImportError:
         from sheets_api import get_sheets_api
         from user_app import session as session_state
         from user_app.db_local import LocalDB
+
+from consts import STATUS_ACTIVE
 
 logger = logging.getLogger(__name__)
 
@@ -379,13 +382,36 @@ class LoginWindow(QDialog):
                     )
 
                 # 2. Создаем новую сессию
-                session_id = f"{email[:8]}_{QDateTime.currentDateTime().toString('yyyyMMddHHmmss')}"
+                login_dt = dt.datetime.now(dt.UTC)
+                session_id = session_state.generate_session_id(email, login_dt)
+                login_time_iso = login_dt.isoformat()
                 self.sheets_api.set_active_session(
                     email,
                     normalized_user_data.get("name", ""),
                     session_id,
-                    QDateTime.currentDateTime().toString(Qt.ISODate),
+                    login_time_iso,
                 )
+                try:
+                    db = LocalDB()
+                    db.mark_session_active(
+                        session_id,
+                        email=normalized_user_data.get("email", email),
+                        name=normalized_user_data.get("name", email),
+                        status=STATUS_ACTIVE,
+                        started_at=login_dt,
+                        comment="Начало смены",
+                        user_group=normalized_user_data.get("group") or None,
+                    )
+                except Exception as exc:
+                    logger.warning(
+                        "Не удалось зафиксировать локальную сессию %s: %s",
+                        session_id,
+                        exc,
+                    )
+                try:
+                    session_state.set_session_id(session_id)
+                except Exception:
+                    logger.debug("Не удалось сохранить session_id в session_state")
                 login_was_performed = True
                 # --- КОНЕЦ ---
 
@@ -399,6 +425,7 @@ class LoginWindow(QDialog):
                     "group": normalized_user_data.get("group", ""),
                     "login_was_performed": login_was_performed,
                     "session_id": session_id,
+                    "session_started_at": login_time_iso,
                 }
 
                 # сохраняем email текущего пользователя для всех подсистем

--- a/user_app/main.py
+++ b/user_app/main.py
@@ -19,12 +19,6 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 from auto_sync import SyncManager  # ← добавили
-from consts import (
-    STATUS_ACTIVE,
-    STATUS_FORCE_LOGOUT,
-    STATUS_LOGOUT,
-    normalize_session_status,
-)
 
 # Инициализация логирования через единый модуль
 from config import (
@@ -33,6 +27,12 @@ from config import (
     HEARTBEAT_PERIOD_SEC,
     LOG_DIR,
     get_credentials_file,
+)
+from consts import (
+    STATUS_ACTIVE,
+    STATUS_FORCE_LOGOUT,
+    STATUS_LOGOUT,
+    normalize_session_status,
 )
 from logging_setup import setup_logging
 from notifications.engine import start_background_poller
@@ -84,9 +84,7 @@ def _hb_loop(
         if suppress_evt and suppress_evt.is_set():
             return
         try:
-            raw_status = api.get_session_status(
-                session_id=session_id, email=email
-            )
+            raw_status = api.get_session_status(session_id=session_id, email=email)
         except Exception as exc:  # pragma: no cover - защита от сетевых ошибок
             logger.debug("Heartbeat remote check failed: %s", exc)
             return
@@ -495,12 +493,7 @@ class ApplicationManager(QObject):
             )
             return
 
-        if (
-            reason.startswith("remote")
-            and record_id
-            and record_id > 0
-            and created
-        ):
+        if reason.startswith("remote") and record_id and record_id > 0 and created:
             try:
                 db.mark_actions_synced([record_id])
             except Exception as exc:

--- a/user_app/main.py
+++ b/user_app/main.py
@@ -19,6 +19,12 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 from auto_sync import SyncManager  # ← добавили
+from consts import (
+    STATUS_ACTIVE,
+    STATUS_FORCE_LOGOUT,
+    STATUS_LOGOUT,
+    normalize_session_status,
+)
 
 # Инициализация логирования через единый модуль
 from config import (
@@ -69,32 +75,38 @@ def _hb_loop(
     if period <= 0:
         period = 60
 
-    active_statuses = {"active", "в работе"}
     remote_emitted = False
 
     def _check_remote() -> None:
         nonlocal remote_emitted
-        if remote_emitted or not session_signals or not email:
+        if remote_emitted:
             return
         if suppress_evt and suppress_evt.is_set():
             return
         try:
-            status = (
-                (api.get_session_status(email=email, session_id=session_id) or "")
-                .strip()
-                .lower()
+            raw_status = api.get_session_status(
+                session_id=session_id, email=email
             )
-        except (
-            Exception
-        ) as exc:  # pragma: no cover - доп. страховка от неожиданных исключений
+        except Exception as exc:  # pragma: no cover - защита от сетевых ошибок
             logger.debug("Heartbeat remote check failed: %s", exc)
             return
-        if status and status not in active_statuses:
+
+        normalized_status = normalize_session_status(raw_status)
+        logger.info(
+            "heartbeat status=%s session=%s",
+            normalized_status or "<unknown>",
+            session_id,
+        )
+
+        if not session_signals or not email:
+            return
+
+        if normalized_status and normalized_status != STATUS_ACTIVE:
             remote_emitted = True
             logger.info(
                 "Heartbeat detected non-active status (session=%s, status=%s)",
                 session_id,
-                status,
+                normalized_status,
             )
             session_signals.sessionFinished.emit("remote_force_logout")
             stop_evt.set()
@@ -147,6 +159,7 @@ class ApplicationManager(QObject):
         self._pending_finish_reason: str | None = None
         self._returning_to_login = False
         self._suppress_remote_checks = threading.Event()
+        self._session_already_terminated = False
 
         offline_mode = False
         try:
@@ -277,7 +290,9 @@ class ApplicationManager(QObject):
             # QThread + worker
             self.sync_thread = QThread(self)
             self.sync_worker = SyncManager(
-                signals=self.sync_signals, background_mode=True
+                signals=self.sync_signals,
+                background_mode=True,
+                session_signals=self.session_signals,
             )
             if offline_mode:
                 # мягкий режим восстановления сети
@@ -347,6 +362,9 @@ class ApplicationManager(QObject):
             if "login_was_performed" in user_data:
                 login_was_performed = bool(user_data["login_was_performed"])
 
+            self._session_already_terminated = False
+            session_started_at = user_data.get("session_started_at")
+
             self._suppress_remote_checks.clear()
             self._pending_finish_reason = None
 
@@ -374,15 +392,18 @@ class ApplicationManager(QObject):
                 group=user_data.get("group", ""),
                 session_signals=self.session_signals,
                 on_session_finish_requested=self.handle_session_finish_requested,
+                session_started_at=session_started_at,
             )
             self.main_window.show()
 
             # подключаем «принудительный разлогин» из сервиса синхронизации
-            self.sync_signals.force_logout.connect(
-                self.main_window.force_logout_by_admin
-            )
+            try:
+                self.sync_signals.force_logout.disconnect()
+            except TypeError:
+                pass
+            self.sync_signals.force_logout.connect(self._emit_remote_force_logout)
             logger = logging.getLogger(__name__)
-            logger.info("force_logout сигнал подключён к force_logout_by_admin")
+            logger.info("force_logout сигнал подключён к sessionFinished")
 
             actual_session_id = getattr(self.main_window, "session_id", session_id)
             self._current_session_id = actual_session_id
@@ -427,6 +448,9 @@ class ApplicationManager(QObject):
             logger.info("Session finish requested (local)")
         self.return_to_login(normalized)
 
+    def _emit_remote_force_logout(self) -> None:
+        self.session_signals.sessionFinished.emit("remote_force_logout")
+
     def _finalize_local_session(self, reason: str) -> None:
         logger = logging.getLogger(__name__)
         window = self.main_window
@@ -435,11 +459,13 @@ class ApplicationManager(QObject):
         if not email or not session_id:
             return
 
-        status_value = "FORCE_LOGOUT" if reason.startswith("remote") else "LOGOUT"
+        status_value = (
+            STATUS_FORCE_LOGOUT if reason.startswith("remote") else STATUS_LOGOUT
+        )
         comment = (
             "Сессия завершена администратором"
             if reason.startswith("remote")
-            else "Завершение смены"
+            else "Смена завершена"
         )
 
         try:
@@ -449,42 +475,32 @@ class ApplicationManager(QObject):
             return
 
         record_id: int | None = None
+        created = False
         try:
-            with db_local.write_tx() as conn:
-                try:
-                    db.finish_last_status_tx(
-                        conn,
-                        email,
-                        session_id,
-                        reason=status_value,
-                    )
-                except TypeError:
-                    db.finish_last_status_tx(conn, email, session_id)
-
-                if not db.check_existing_logout(email, session_id):
-                    now_iso = dt.datetime.now(dt.UTC).isoformat()
-                    name_value = getattr(window, "name", "") or email
-                    group_value = getattr(window, "group", None)
-                    record_id = db.log_action_tx(
-                        conn=conn,
-                        email=email,
-                        name=name_value,
-                        status=status_value,
-                        action_type="LOGOUT",
-                        comment=comment,
-                        session_id=session_id,
-                        status_start_time=now_iso,
-                        status_end_time=now_iso,
-                        reason=status_value,
-                        user_group=group_value,
-                    )
+            name_value = getattr(window, "name", "") or email
+            group_value = getattr(window, "group", None)
+            record_id, created = db.finish_session(
+                session_id,
+                email=email,
+                name=name_value,
+                status=status_value,
+                comment=comment,
+                reason=status_value,
+                logout_time=dt.datetime.now(dt.UTC),
+                user_group=group_value,
+            )
         except Exception as exc:
             logger.warning(
                 "Finalize local session failed (session=%s): %s", session_id, exc
             )
             return
 
-        if reason.startswith("remote") and record_id and record_id > 0:
+        if (
+            reason.startswith("remote")
+            and record_id
+            and record_id > 0
+            and created
+        ):
             try:
                 db.mark_actions_synced([record_id])
             except Exception as exc:
@@ -515,9 +531,9 @@ class ApplicationManager(QObject):
     def _show_logout_message(self, reason: str) -> None:
         reason_key = (reason or "").strip().lower()
         messages = {
-            "local_logout": "Смена завершена.",
+            "local_logout": "Смена завершена",
             "local_logout_offline": "Смена будет завершена при восстановлении сети.",
-            "remote_force_logout": "Сессия завершена администратором.",
+            "remote_force_logout": "Сессия завершена администратором",
         }
         message = messages.get(reason_key)
         if not message:
@@ -542,6 +558,13 @@ class ApplicationManager(QObject):
     def return_to_login(self, reason: str) -> None:
         logger = logging.getLogger(__name__)
         normalized = (reason or "").strip().lower() or "local_logout"
+        if self._session_already_terminated:
+            logger.debug(
+                "Session already terminated, skip return_to_login (reason=%s)",
+                normalized,
+            )
+            return
+        self._session_already_terminated = True
         if self._returning_to_login:
             logger.debug(
                 "Return to login already in progress (skip reason=%s)", normalized

--- a/user_app/session.py
+++ b/user_app/session.py
@@ -1,6 +1,7 @@
 # user_app/session.py
 from __future__ import annotations
 
+import datetime as dt
 import threading
 from typing import Optional
 
@@ -30,3 +31,11 @@ def set_session_id(session_id: str) -> None:
 def get_session_id() -> Optional[str]:
     with _lock:
         return _current_session_id
+
+
+def generate_session_id(email: str, moment: dt.datetime | None = None) -> str:
+    """Generate a canonical session identifier (email + UTC timestamp)."""
+
+    timestamp = (moment or dt.datetime.now(dt.UTC)).strftime("%Y%m%d%H%M%S")
+    normalized_email = (email or "").strip().lower()
+    return f"{normalized_email}_{timestamp}"


### PR DESCRIPTION
## Summary
- add `consts.py` with canonical session status constants and reuse them across the user app, auto-sync service, and Sheets API integrations
- generate and persist canonical session identifiers on login, wire them through local DB helpers, and harden GUI logic around finishing statuses, timers, and idempotent return-to-login flows
- update heartbeat and auto-sync watchers to normalize status checks, acknowledge remote logout commands, and log precise session status data in Sheets API

## Testing
- python -m compileall auto_sync.py user_app sheets_api.py consts.py config.py

------
https://chatgpt.com/codex/tasks/task_e_68cd35d84b5083278f898882626916d4