### PR TITLE
Improve login responsiveness, async logout, and WorkLog sorting

### DIFF
--- a/config.py
+++ b/config.py
@@ -51,6 +51,7 @@ def _read_env_float(var_name: str, default: float) -> float:
     except ValueError:
         return default
 
+
 # ==================== Импорт для работы с зашифрованным credentials ====================
 import pyzipper
 
@@ -210,7 +211,9 @@ WORKLOG_HEADERS = [
 
 # WorkLog сортировки (перестановка строк в листе)
 WORKLOG_SORT_ON_APPEND = _read_env_bool("WORKLOG_SORT_ON_APPEND", True)
-_WORKLOG_SCOPE_DEFAULT = (os.getenv("WORKLOG_SORT_SCOPE", "today") or "today").strip().lower()
+_WORKLOG_SCOPE_DEFAULT = (
+    (os.getenv("WORKLOG_SORT_SCOPE", "today") or "today").strip().lower()
+)
 if _WORKLOG_SCOPE_DEFAULT not in {"all", "today", "lastnhours"}:
     _WORKLOG_SCOPE_DEFAULT = "today"
 WORKLOG_SORT_SCOPE = _WORKLOG_SCOPE_DEFAULT

--- a/config.py
+++ b/config.py
@@ -41,6 +41,16 @@ def _read_env_bool(var_name: str, default: bool = False) -> bool:
 
 DEBUG_IDS: bool = _read_env_bool("DEBUG_IDS", False)
 
+
+def _read_env_float(var_name: str, default: float) -> float:
+    value = os.getenv(var_name)
+    if value is None or value == "":
+        return default
+    try:
+        return float(value)
+    except ValueError:
+        return default
+
 # ==================== Импорт для работы с зашифрованным credentials ====================
 import pyzipper
 
@@ -197,6 +207,27 @@ WORKLOG_HEADERS = [
     "EventID",
     "GroupAtStart",
 ]
+
+# WorkLog сортировки (перестановка строк в листе)
+WORKLOG_SORT_ON_APPEND = _read_env_bool("WORKLOG_SORT_ON_APPEND", True)
+_WORKLOG_SCOPE_DEFAULT = (os.getenv("WORKLOG_SORT_SCOPE", "today") or "today").strip().lower()
+if _WORKLOG_SCOPE_DEFAULT not in {"all", "today", "lastnhours"}:
+    _WORKLOG_SCOPE_DEFAULT = "today"
+WORKLOG_SORT_SCOPE = _WORKLOG_SCOPE_DEFAULT
+WORKLOG_SORT_LAST_HOURS = _read_env_int("WORKLOG_SORT_LAST_HOURS", 24)
+WORKLOG_SORT_SECONDARY = (
+    os.getenv("WORKLOG_SORT_SECONDARY", "Timestamp").strip() or "Timestamp"
+)
+WORKLOG_SORT_DEBOUNCE_SECONDS = _read_env_int("WORKLOG_SORT_DEBOUNCE_SECONDS", 10)
+
+# Серверная база данных (дополнительное хранилище)
+SERVER_DB_ENABLED = _read_env_bool("SERVER_DB_ENABLED", False)
+SERVER_DB_BASE_URL = os.getenv("SERVER_DB_BASE_URL", "").strip()
+SERVER_DB_TIMEOUT = _read_env_float("SERVER_DB_TIMEOUT", 5.0)
+SERVER_DB_AUTH_TOKEN = os.getenv("SERVER_DB_AUTH_TOKEN", "").strip() or None
+
+# Таймауты Google API (секунды)
+GOOGLE_API_TIMEOUT = _read_env_float("GOOGLE_API_TIMEOUT", 15.0)
 
 ARCHIVE_SHEET = "Archive"
 ACTIVE_SESSIONS_SHEET = "ActiveSessions"

--- a/sheets_api.py
+++ b/sheets_api.py
@@ -200,9 +200,7 @@ class SheetsAPI:
                 ):
                     self.client.http_client.timeout = timeout
 
-                self._session = _TimeoutAuthorizedSession(
-                    credentials, timeout=timeout
-                )
+                self._session = _TimeoutAuthorizedSession(credentials, timeout=timeout)
 
                 self._test_connection()
                 self._update_quota_info()
@@ -982,11 +980,7 @@ class SheetsAPI:
                 return hmap.get(name.lower())
 
             c_status = col("Status") or col("status")
-            c_logout = (
-                col("LogoutTime")
-                or col("logouttime")
-                or col("logout time")
-            )
+            c_logout = col("LogoutTime") or col("logouttime") or col("logout time")
             if not (c_status and c_logout):
                 raise SheetsAPIError("ActiveSessions headers missing Status/LogoutTime")
 
@@ -1599,7 +1593,9 @@ class SheetsAPI:
         for column in columns:
             idx = header_map.get(column)
             if not idx:
-                logger.debug("sort_worklog: column %s missing for group=%s", column, group)
+                logger.debug(
+                    "sort_worklog: column %s missing for group=%s", column, group
+                )
                 continue
             sort_specs.append({"dimensionIndex": idx - 1, "sortOrder": "ASCENDING"})
         if not sort_specs:

--- a/sheets_api.py
+++ b/sheets_api.py
@@ -19,6 +19,7 @@ import gspread
 from google.auth.transport.requests import AuthorizedSession
 from google.oauth2.service_account import Credentials
 
+from config import GOOGLE_API_TIMEOUT
 from consts import normalize_session_status
 from telemetry import trace_time
 
@@ -46,6 +47,17 @@ class QuotaInfo:
 class WorklogWorksheetInfo:
     worksheet: Any
     header_to_col_index: dict[str, int]
+
+
+class _TimeoutAuthorizedSession(AuthorizedSession):
+    def __init__(self, credentials, *, timeout: float):
+        super().__init__(credentials)
+        self._default_timeout = max(1.0, float(timeout))
+
+    def request(self, method, url, **kwargs):  # type: ignore[override]
+        if "timeout" not in kwargs or kwargs["timeout"] is None:
+            kwargs["timeout"] = self._default_timeout
+        return super().request(method, url, **kwargs)
 
 
 class SheetsAPIError(Exception):
@@ -179,22 +191,18 @@ class SheetsAPI:
                 credentials = Credentials.from_service_account_file(
                     str(self.credentials_path), scopes=scopes
                 )
+                timeout = GOOGLE_API_TIMEOUT
                 self.client = gspread.client.Client(auth=credentials)
-                # gspread >=5
-                self.client.session = AuthorizedSession(credentials)
-                # На некоторых версиях http_client может отсутствовать — оставляем, как было у тебя
+                session = _TimeoutAuthorizedSession(credentials, timeout=timeout)
+                self.client.session = session
                 if hasattr(self.client, "http_client") and hasattr(
                     self.client.http_client, "timeout"
                 ):
-                    self.client.http_client.timeout = 30
+                    self.client.http_client.timeout = timeout
 
-                self._session = AuthorizedSession(credentials)
-                # У объекта AuthorizedSession нет атрибута timeout во всех версиях,
-                # но если есть — выставим.
-                try:
-                    self._session.timeout = 30  # type: ignore[attr-defined]
-                except Exception:
-                    pass
+                self._session = _TimeoutAuthorizedSession(
+                    credentials, timeout=timeout
+                )
 
                 self._test_connection()
                 self._update_quota_info()
@@ -940,6 +948,22 @@ class SheetsAPI:
         *,
         reason: str | None = None,
     ) -> bool:
+        with trace_time("finish_active_session"):
+            return self._finish_active_session_impl(
+                email=email,
+                session_id=session_id,
+                logout_time=logout_time,
+                reason=reason,
+            )
+
+    def _finish_active_session_impl(
+        self,
+        *,
+        email: str,
+        session_id: str,
+        logout_time: str | None = None,
+        reason: str | None = None,
+    ) -> bool:
         """
         Надёжно завершает активную сессию:
         1) Пытается найти точный матч по Email+SessionID (безусловно обновляет статус/время).
@@ -954,12 +978,15 @@ class SheetsAPI:
             sid = str(session_id or "").strip()
             hmap = self._header_map(ws)  # lower -> index
 
-            # индексы с защитой разных регистров
-            def col(name):
+            def col(name: str) -> int | None:
                 return hmap.get(name.lower())
 
             c_status = col("Status") or col("status")
-            c_logout = col("LogoutTime") or col("logouttime") or col("logout time")
+            c_logout = (
+                col("LogoutTime")
+                or col("logouttime")
+                or col("logout time")
+            )
             if not (c_status and c_logout):
                 raise SheetsAPIError("ActiveSessions headers missing Status/LogoutTime")
 
@@ -999,7 +1026,7 @@ class SheetsAPI:
                 )
                 return True
 
-            if exact_match := next(
+            exact_match = next(
                 (
                     (i, r)
                     for i, r in enumerate(table, start=2)
@@ -1007,11 +1034,11 @@ class SheetsAPI:
                     and str(r.get("SessionID", "")).strip() == sid
                 ),
                 None,
-            ):
+            )
+            if exact_match:
                 row_idx, row_dict = exact_match
                 return apply_update(row_idx, row_dict)
 
-            # 2) фоллбэк: последняя активная по email
             candidates = [
                 (i, r)
                 for i, r in enumerate(table, start=2)
@@ -1020,13 +1047,14 @@ class SheetsAPI:
             ]
             if not candidates:
                 logger.warning(
-                    f"finish_active_session: no active rows for email={email}, sid={session_id}"
+                    "finish_active_session: no active rows for email=%s, sid=%s",
+                    email,
+                    session_id,
                 )
                 return False
 
-            # выбираем по максимальному LoginTime (как строка, формат единообразный)
-            def sort_key(t):
-                idx, row = t
+            def sort_key(item):
+                idx, row = item
                 return ((row.get("LoginTime") or "").strip(), idx)
 
             row_idx, row_dict = sorted(candidates, key=sort_key)[-1]
@@ -1164,43 +1192,44 @@ class SheetsAPI:
 
         from config import ACTIVE_SESSIONS_SHEET
 
-        sid = str(session_id or "").strip()
-        if not sid:
-            return None
+        with trace_time("check_user_session_status"):
+            sid = str(session_id or "").strip()
+            if not sid:
+                return None
 
-        ws = self._get_ws(ACTIVE_SESSIONS_SHEET)
-        table = self._read_table(ws)
-        em = (email or "").strip().lower()
-        fallback_row: dict[str, Any] | None = None
-        fallback_row_idx: int | None = None
+            ws = self._get_ws(ACTIVE_SESSIONS_SHEET)
+            table = self._read_table(ws)
+            em = (email or "").strip().lower()
+            fallback_row: dict[str, Any] | None = None
+            fallback_row_idx: int | None = None
 
-        for row_idx, row in enumerate(table, start=2):
-            row_sid = str(row.get("SessionID", "") or "").strip()
-            if row_sid == sid:
-                status_value = normalize_session_status(row.get("Status"))
+            for row_idx, row in enumerate(table, start=2):
+                row_sid = str(row.get("SessionID", "") or "").strip()
+                if row_sid == sid:
+                    status_value = normalize_session_status(row.get("Status"))
+                    logger.info(
+                        "ActiveSessions status for session=%s -> %s",
+                        sid,
+                        status_value or "<unknown>",
+                    )
+                    return status_value
+                if em and (row.get("Email", "") or "").strip().lower() == em:
+                    fallback_row = row
+                    fallback_row_idx = row_idx
+
+            if fallback_row:
+                status_value = normalize_session_status(fallback_row.get("Status"))
                 logger.info(
-                    "ActiveSessions status for session=%s -> %s",
+                    "ActiveSessions status for session=%s (email=%s row=%s) -> %s",
                     sid,
+                    em or "<unknown>",
+                    fallback_row_idx if fallback_row_idx is not None else "<unknown>",
                     status_value or "<unknown>",
                 )
                 return status_value
-            if em and (row.get("Email", "") or "").strip().lower() == em:
-                fallback_row = row
-                fallback_row_idx = row_idx
 
-        if fallback_row:
-            status_value = normalize_session_status(fallback_row.get("Status"))
-            logger.info(
-                "ActiveSessions status for session=%s (email=%s row=%s) -> %s",
-                sid,
-                em or "<unknown>",
-                fallback_row_idx if fallback_row_idx is not None else "<unknown>",
-                status_value or "<unknown>",
-            )
-            return status_value
-
-        logger.info("ActiveSessions status for session=%s -> not found", sid)
-        return None
+            logger.info("ActiveSessions status for session=%s -> not found", sid)
+            return None
 
     def ack_remote_command(self, email: str, session_id: str) -> bool:
         """Очищает RemoteCommand в ActiveSessions по (email, session_id)."""
@@ -1346,9 +1375,10 @@ class SheetsAPI:
                     row.extend([""] * (col - len(row)))
                 row[col - 1] = value
 
-            self._request_with_retry(
-                info.worksheet.append_row, row, value_input_option="USER_ENTERED"
-            )
+            with trace_time("append_worklog"):
+                self._request_with_retry(
+                    info.worksheet.append_row, row, value_input_option="USER_ENTERED"
+                )
             logger.info(
                 f"WorkLog append: {event_id} (session={session_id or '-'}, group={target_group})"
             )
@@ -1549,6 +1579,141 @@ class SheetsAPI:
                 is_retryable=True,
                 details=str(e),
             ) from e
+
+    def sort_worklog(
+        self,
+        group: str,
+        *,
+        scope: str = "today",
+        by: list[str] | None = None,
+        last_hours: int | None = None,
+    ) -> None:
+        info = self.get_or_create_worklog_ws(group)
+        header_map = info.header_to_col_index
+        if not header_map:
+            logger.debug("sort_worklog skipped: no headers for group=%s", group)
+            return
+
+        columns = by or ["Start", "Timestamp"]
+        sort_specs = []
+        for column in columns:
+            idx = header_map.get(column)
+            if not idx:
+                logger.debug("sort_worklog: column %s missing for group=%s", column, group)
+                continue
+            sort_specs.append({"dimensionIndex": idx - 1, "sortOrder": "ASCENDING"})
+        if not sort_specs:
+            logger.debug("sort_worklog skipped: no valid columns for group=%s", group)
+            return
+
+        range_indices = self._resolve_sort_range(
+            info,
+            scope=scope,
+            last_hours=last_hours,
+        )
+        if not range_indices:
+            return
+        start_row_index, end_row_index = range_indices
+        if end_row_index <= start_row_index:
+            logger.debug(
+                "sort_worklog skipped: empty range for group=%s (scope=%s)",
+                group,
+                scope,
+            )
+            return
+
+        max_col = max(header_map.values())
+        body = {
+            "requests": [
+                {
+                    "sortRange": {
+                        "range": {
+                            "sheetId": info.worksheet.id,
+                            "startRowIndex": start_row_index,
+                            "endRowIndex": end_row_index,
+                            "startColumnIndex": 0,
+                            "endColumnIndex": max_col,
+                        },
+                        "sortSpecs": sort_specs,
+                    }
+                }
+            ]
+        }
+        spreadsheet = info.worksheet.spreadsheet
+        with trace_time("sort_worklog"):
+            self._request_with_retry(spreadsheet.batch_update, body)
+
+    def _resolve_sort_range(
+        self,
+        info: WorklogWorksheetInfo,
+        *,
+        scope: str,
+        last_hours: int | None = None,
+    ) -> tuple[int, int] | None:
+        header_map = info.header_to_col_index
+        if not header_map:
+            return None
+        max_col = max(header_map.values())
+        data_range = f"A2:{self._num_to_a1_col(max_col)}"
+        try:
+            values = self._request_with_retry(info.worksheet.get_values, data_range)
+        except Exception as exc:
+            logger.debug(
+                "sort_worklog: failed to fetch range for %s: %s",
+                info.worksheet.title,
+                exc,
+            )
+            return None
+        if not values:
+            return None
+
+        start_row_index = 1  # skip header
+        end_row_index = 1 + len(values)
+
+        scope_value = (scope or "").strip().lower()
+        if scope_value == "all":
+            return start_row_index, end_row_index
+
+        cutoff: dt.datetime | None = None
+        if scope_value == "today":
+            cutoff = dt.datetime.now(dt.UTC).replace(
+                hour=0, minute=0, second=0, microsecond=0
+            )
+        elif scope_value == "lastnhours" and last_hours:
+            cutoff = dt.datetime.now(dt.UTC) - dt.timedelta(
+                hours=max(1, int(last_hours))
+            )
+        if cutoff is None:
+            return start_row_index, end_row_index
+
+        start_col = header_map.get("Start")
+        timestamp_col = header_map.get("Timestamp")
+        for offset, row in enumerate(values, start=2):
+            row_dt = self._extract_row_datetime(row, start_col, timestamp_col)
+            if row_dt and row_dt >= cutoff:
+                return offset - 1, end_row_index
+
+        # nothing to sort within the requested window
+        return end_row_index, end_row_index
+
+    def _extract_row_datetime(
+        self,
+        row: list[Any],
+        start_col: int | None,
+        timestamp_col: int | None,
+    ) -> dt.datetime | None:
+        candidates: list[dt.datetime] = []
+        if start_col and start_col - 1 < len(row):
+            candidate = self._as_utc_datetime(row[start_col - 1])
+            if candidate:
+                candidates.append(candidate)
+        if timestamp_col and timestamp_col - 1 < len(row):
+            candidate = self._as_utc_datetime(row[timestamp_col - 1])
+            if candidate:
+                candidates.append(candidate)
+        if not candidates:
+            return None
+        return min(candidates)
 
     # ---------- utils ----------
 

--- a/telemetry.py
+++ b/telemetry.py
@@ -5,7 +5,6 @@ import time
 from contextlib import contextmanager
 from typing import Iterator
 
-
 _WARN_THRESHOLDS_MS: dict[str, float] = {
     "login": 3000.0,
     "finish_active_session": 2000.0,

--- a/telemetry.py
+++ b/telemetry.py
@@ -6,9 +6,20 @@ from contextlib import contextmanager
 from typing import Iterator
 
 
+_WARN_THRESHOLDS_MS: dict[str, float] = {
+    "login": 3000.0,
+    "finish_active_session": 2000.0,
+}
+
+_WARN_HINTS: dict[str, str] = {
+    "login": "Замер входа превысил 3 секунды — проверьте подключение к сети или кеш API.",
+    "finish_active_session": "Завершение сессии выполняется слишком долго (более 2 секунд).",
+}
+
+
 @contextmanager
 def trace_time(label: str, *, logger: logging.Logger | None = None) -> Iterator[None]:
-    """Log execution time for a block in milliseconds."""
+    """Log execution time for a block in milliseconds with optional warnings."""
 
     log = logger or logging.getLogger("telemetry")
     start = time.perf_counter()
@@ -16,4 +27,12 @@ def trace_time(label: str, *, logger: logging.Logger | None = None) -> Iterator[
         yield
     finally:
         duration_ms = (time.perf_counter() - start) * 1000
-        log.info("op=%s took %.1f ms", label, duration_ms)
+        threshold = _WARN_THRESHOLDS_MS.get(label)
+        message = f"op={label} took {duration_ms:.1f} ms"
+        if threshold is not None and duration_ms > threshold:
+            hint = _WARN_HINTS.get(label)
+            if hint:
+                message = f"{message} — {hint}"
+            log.warning(message)
+        else:
+            log.info(message)

--- a/user_app/app_controller.py
+++ b/user_app/app_controller.py
@@ -47,10 +47,13 @@ class AppController(QObject):
         self._pending_finish_reason: str | None = None
         self._remote_logout_triggered = False
         self._last_message: str | None = None
+        self._last_known_group: str | None = None
 
         self.session_signals = self.services.session_signals
         self.sync_signals = self.services.sync_signals
         self.session_signals.sessionFinished.connect(self._handle_session_finished)
+        if hasattr(self.session_signals, "sessionFinalized"):
+            self.session_signals.sessionFinalized.connect(self._handle_session_finalized)
         self.sync_signals.force_logout.connect(
             lambda: self.handle_remote_force_logout("remote_force_logout")
         )
@@ -206,9 +209,14 @@ class AppController(QObject):
         session_id = user_data.get("session_id") or ""
         session_state.set_session_id(session_id)
         session_state.set_user_email(user_data.get("email", ""))
+        self._last_known_group = user_data.get("group", "")
 
         self._create_main_window(user_data)
         self.to_active(session_id)
+        try:
+            self.services.schedule_worklog_sort(self._last_known_group or "")
+        except Exception:
+            logger.debug("Worklog sort scheduling failed after login", exc_info=True)
 
     def _on_login_failed(self, message: str) -> None:
         self._current_user = None
@@ -233,6 +241,14 @@ class AppController(QObject):
             self.handle_remote_force_logout(normalized)
         else:
             self.to_returning_to_login(normalized)
+
+    def _handle_session_finalized(self, reason: str) -> None:
+        normalized = (reason or "").strip()
+        message = self._logout_message(normalized)
+        self._last_message = message
+        if self.login_window:
+            self.login_window.show_info(message)
+        logger.info("Logout finalized with reason=%s", normalized or "<empty>")
 
     # --- Remote handling ----------------------------------------------
     def handle_remote_force_logout(self, reason: str) -> None:
@@ -268,6 +284,10 @@ class AppController(QObject):
                 self.services.submit(_ack)
 
         self.remote_logout.emit(logout_reason)
+        try:
+            self.services.schedule_worklog_sort(self._last_known_group or "")
+        except Exception:
+            logger.debug("Failed to schedule WorkLog sort after remote logout", exc_info=True)
 
     # --- Helpers ------------------------------------------------------
     def _create_main_window(self, user_data: Dict[str, Any]) -> None:
@@ -428,7 +448,7 @@ class AppController(QObject):
                 if active_session:
                     existing_sid = active_session.get("SessionID")
                     if existing_sid:
-                        with trace_time("logout"):
+                        with trace_time("finish_active_session"):
                             sheets.finish_active_session(email, existing_sid)
 
                 sheets.set_active_session(
@@ -451,6 +471,20 @@ class AppController(QObject):
             )
             if created and record_id:
                 QTimer.singleShot(0, lambda: logger.debug("Local session recorded"))
+
+            try:
+                self.services.replicate_session_start(
+                    {
+                        "session_id": session_id,
+                        "email": normalized.get("email", email),
+                        "name": normalized.get("name", ""),
+                        "status": STATUS_ACTIVE,
+                        "started_at": login_time_iso,
+                        "group": normalized.get("group") or None,
+                    }
+                )
+            except Exception:  # pragma: no cover - replication is best-effort
+                logger.debug("Failed to replicate session start to server DB", exc_info=True)
 
             session_state.set_session_id(session_id)
             session_state.set_user_email(normalized.get("email", email))

--- a/user_app/app_controller.py
+++ b/user_app/app_controller.py
@@ -53,7 +53,9 @@ class AppController(QObject):
         self.sync_signals = self.services.sync_signals
         self.session_signals.sessionFinished.connect(self._handle_session_finished)
         if hasattr(self.session_signals, "sessionFinalized"):
-            self.session_signals.sessionFinalized.connect(self._handle_session_finalized)
+            self.session_signals.sessionFinalized.connect(
+                self._handle_session_finalized
+            )
         self.sync_signals.force_logout.connect(
             lambda: self.handle_remote_force_logout("remote_force_logout")
         )
@@ -287,7 +289,9 @@ class AppController(QObject):
         try:
             self.services.schedule_worklog_sort(self._last_known_group or "")
         except Exception:
-            logger.debug("Failed to schedule WorkLog sort after remote logout", exc_info=True)
+            logger.debug(
+                "Failed to schedule WorkLog sort after remote logout", exc_info=True
+            )
 
     # --- Helpers ------------------------------------------------------
     def _create_main_window(self, user_data: Dict[str, Any]) -> None:
@@ -484,7 +488,9 @@ class AppController(QObject):
                     }
                 )
             except Exception:  # pragma: no cover - replication is best-effort
-                logger.debug("Failed to replicate session start to server DB", exc_info=True)
+                logger.debug(
+                    "Failed to replicate session start to server DB", exc_info=True
+                )
 
             session_state.set_session_id(session_id)
             session_state.set_user_email(normalized.get("email", email))

--- a/user_app/gui.py
+++ b/user_app/gui.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 import sys
 import time
+from concurrent.futures import Future
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Callable, Optional
@@ -264,6 +265,16 @@ class EmployeeApp(QWidget):
             else:
                 self.db.mark_actions_synced([prev_id])
                 self.last_sync_time = datetime.now()
+                try:
+                    payload = dict(action)
+                    payload["group"] = target_group
+                    self.services.replicate_action(payload)
+                except Exception:  # pragma: no cover - replication best effort
+                    logger.debug("Server DB action replication failed", exc_info=True)
+                try:
+                    self.services.schedule_worklog_sort(self.group)
+                except Exception:
+                    logger.debug("Failed to schedule WorkLog sort", exc_info=True)
         except Exception as e:
             logger.warning(f"Ошибка отправки завершённого статуса в Sheets: {e}")
             Notifier.show(
@@ -280,8 +291,6 @@ class EmployeeApp(QWidget):
     def _disable_post_logout(self) -> None:
         self.shift_ended = True
         self.finish_btn.setEnabled(False)
-        for btn in self.status_buttons.values():
-            btn.setEnabled(False)
 
     def _emit_session_finished(self, reason: str) -> None:
         self._logout_in_progress = False
@@ -297,10 +306,12 @@ class EmployeeApp(QWidget):
             except TypeError:
                 self.on_logout_callback()
 
-    def _start_logout_worker(self, mode: str) -> None:
-        self._executor.submit(self._logout_worker, mode)
+    def _start_logout_worker(self, mode: str) -> Future[str]:
+        future: Future[str] = self._executor.submit(self._logout_worker, mode)
+        future.add_done_callback(self._on_logout_worker_done)
+        return future
 
-    def _logout_worker(self, mode: str) -> None:
+    def _logout_worker(self, mode: str) -> str:
         reason = "local_logout"
         try:
             if mode == "local":
@@ -314,8 +325,29 @@ class EmployeeApp(QWidget):
                 reason = "remote_force_logout"
             else:
                 reason = mode
+        except Exception as exc:  # pragma: no cover - network failures tolerated
+            logger.debug("Logout worker encountered error: %s", exc)
+            reason = "local_logout_offline"
+        try:
+            if reason in {"local_logout", "local_logout_offline"}:
+                try:
+                    self.services.schedule_worklog_sort(self.group)
+                except Exception:
+                    logger.debug("Failed to schedule WorkLog sort on logout", exc_info=True)
         finally:
-            self._emit_session_finished(reason)
+            return reason
+
+    def _on_logout_worker_done(self, future: Future[str]) -> None:
+        try:
+            reason = future.result()
+        except Exception as exc:  # pragma: no cover - executor errors
+            logger.debug("Logout worker future failed: %s", exc)
+            reason = "local_logout_offline"
+        if self.session_signals and hasattr(self.session_signals, "sessionFinalized"):
+            try:
+                self.session_signals.sessionFinalized.emit(reason)
+            except Exception as signal_exc:  # pragma: no cover
+                logger.debug("sessionFinalized emit failed: %s", signal_exc)
 
     def _finish_remote_session_with_retry(self) -> tuple[bool, bool]:
         """Возвращает (success, offline_hint)."""
@@ -327,7 +359,7 @@ class EmployeeApp(QWidget):
         for attempt in range(1, 4):
             try:
                 logout_time = datetime.now().isoformat()
-                with trace_time("logout"):
+                with trace_time("finish_active_session"):
                     ok = self.sheets_api.finish_active_session(
                         self.email,
                         self.session_id,
@@ -734,6 +766,20 @@ class EmployeeApp(QWidget):
                             record_id,
                             sync_exc,
                         )
+            try:
+                self.services.replicate_session_finish(
+                    {
+                        "session_id": self.session_id,
+                        "email": self.email,
+                        "name": self.name,
+                        "logout_time": logout_moment.isoformat(),
+                        "reason": status_value,
+                        "comment": comment,
+                        "group": self.group or None,
+                    }
+                )
+            except Exception:  # pragma: no cover - best effort replication
+                logger.debug("Failed to replicate session finish", exc_info=True)
             return record_id if record_id is not None else -1
         except Exception as e:
             logger.error(f"Ошибка записи завершения смены: {e}")
@@ -772,8 +818,9 @@ class EmployeeApp(QWidget):
 
         self._disable_post_logout()
         self.comment_input.clear()
-        Notifier.show("WorkLog", "Идёт завершение смены")
+        Notifier.show("WorkLog", "Завершение смены выполняется в фоне")
         self._start_logout_worker("local")
+        self._emit_session_finished("local_logout")
 
     def closeEvent(self, event):
         if not self.shift_ended:

--- a/user_app/gui.py
+++ b/user_app/gui.py
@@ -333,7 +333,9 @@ class EmployeeApp(QWidget):
                 try:
                     self.services.schedule_worklog_sort(self.group)
                 except Exception:
-                    logger.debug("Failed to schedule WorkLog sort on logout", exc_info=True)
+                    logger.debug(
+                        "Failed to schedule WorkLog sort on logout", exc_info=True
+                    )
         finally:
             return reason
 

--- a/user_app/login_window.py
+++ b/user_app/login_window.py
@@ -6,7 +6,7 @@ import sys
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from PyQt5.QtCore import Qt
+from PyQt5.QtCore import Qt, QTimer
 from PyQt5.QtGui import QFont, QIcon, QPixmap
 from PyQt5.QtWidgets import (
     QDialog,
@@ -38,6 +38,9 @@ class LoginWindow(QDialog):
         self._init_ui()
         self._setup_shortcuts()
         self._connect_controller_signals()
+        self._slow_login_timer = QTimer(self)
+        self._slow_login_timer.setSingleShot(True)
+        self._slow_login_timer.timeout.connect(self._show_slow_login_hint)
 
     # --- UI setup -----------------------------------------------------
     def _resource_path(self, relative_path: str) -> str:
@@ -160,16 +163,19 @@ class LoginWindow(QDialog):
 
     def _on_login_started(self) -> None:
         self._set_loading_state(True, "Выполняется вход...")
+        self._slow_login_timer.start(3000)
 
     def _on_login_failed(self, message: str) -> None:
         self.auth_in_progress = False
         self._set_loading_state(False)
+        self._slow_login_timer.stop()
         if message:
             self._show_error_once(message)
 
     def _on_login_succeeded(self, _: dict) -> None:
         self.auth_in_progress = False
         self._set_loading_state(False)
+        self._slow_login_timer.stop()
         self.status_label.setText("")
         self.hide()
 
@@ -185,6 +191,10 @@ class LoginWindow(QDialog):
             self.status_label.setText(message)
         elif not loading:
             self.status_label.setText("")
+
+    def _show_slow_login_hint(self) -> None:
+        if self.auth_in_progress:
+            self.status_label.setText("Подключение продолжается в фоне...")
 
     def _show_error_once(self, message: str) -> None:
         if self._showing_error:

--- a/user_app/main.py
+++ b/user_app/main.py
@@ -50,6 +50,10 @@ def main() -> None:
         sys.excepthook = _handle_uncaught
 
         controller = AppController(services)
+        try:
+            services.warmup_async()
+        except Exception:  # pragma: no cover - warmup errors are non fatal
+            logging.getLogger(__name__).debug("Warmup scheduling failed", exc_info=True)
         controller.start()
 
         exit_code = app.exec_()

--- a/user_app/server_db.py
+++ b/user_app/server_db.py
@@ -21,7 +21,9 @@ logger = logging.getLogger(__name__)
 class ServerDBClient:
     """Thin HTTP client for optional server-side persistence."""
 
-    def __init__(self, base_url: str, *, timeout: float, token: str | None = None) -> None:
+    def __init__(
+        self, base_url: str, *, timeout: float, token: str | None = None
+    ) -> None:
         normalized = (base_url or "").strip().rstrip("/")
         if not normalized:
             raise ValueError("Server DB base URL must be provided")
@@ -90,7 +92,9 @@ def get_server_db() -> ServerDBClient | None:
         logger.info("Server DB integration disabled via configuration")
         return None
     if not SERVER_DB_BASE_URL:
-        logger.warning("SERVER_DB_BASE_URL is not configured; disabling server DB client")
+        logger.warning(
+            "SERVER_DB_BASE_URL is not configured; disabling server DB client"
+        )
         return None
     try:
         client = ServerDBClient(

--- a/user_app/server_db.py
+++ b/user_app/server_db.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import logging
+import threading
+from typing import Any, Mapping
+
+import requests
+
+from config import (
+    GOOGLE_API_TIMEOUT,
+    SERVER_DB_AUTH_TOKEN,
+    SERVER_DB_BASE_URL,
+    SERVER_DB_ENABLED,
+    SERVER_DB_TIMEOUT,
+)
+from telemetry import trace_time
+
+logger = logging.getLogger(__name__)
+
+
+class ServerDBClient:
+    """Thin HTTP client for optional server-side persistence."""
+
+    def __init__(self, base_url: str, *, timeout: float, token: str | None = None) -> None:
+        normalized = (base_url or "").strip().rstrip("/")
+        if not normalized:
+            raise ValueError("Server DB base URL must be provided")
+        self._base_url = normalized
+        self._timeout = max(1.0, float(timeout))
+        self._session = requests.Session()
+        self._lock = threading.RLock()
+        if token:
+            self._session.headers["Authorization"] = f"Bearer {token}"
+        self._session.headers.setdefault("Content-Type", "application/json")
+
+    def close(self) -> None:
+        with self._lock:
+            try:
+                self._session.close()
+            except Exception:  # pragma: no cover - best effort
+                logger.debug("Server DB session close failed", exc_info=True)
+
+    def ping(self) -> bool:
+        """Best-effort health check; returns True on HTTP 200."""
+
+        try:
+            with trace_time("server_db_ping"):
+                response = self._session.get(
+                    f"{self._base_url}/health",
+                    timeout=min(self._timeout, GOOGLE_API_TIMEOUT),
+                )
+            if response.ok:
+                return True
+            logger.debug(
+                "Server DB ping returned non-OK status: %s", response.status_code
+            )
+        except Exception as exc:  # pragma: no cover - network failures are tolerated
+            logger.debug("Server DB ping failed: %s", exc)
+        return False
+
+    # --- High level operations -------------------------------------------------
+    def record_session_start(self, payload: Mapping[str, Any]) -> None:
+        self._post("sessions/start", payload)
+
+    def record_session_finish(self, payload: Mapping[str, Any]) -> None:
+        self._post("sessions/finish", payload)
+
+    def record_action(self, payload: Mapping[str, Any]) -> None:
+        self._post("actions", payload)
+
+    # --- Internal helpers ------------------------------------------------------
+    def _post(self, path: str, payload: Mapping[str, Any]) -> None:
+        if not payload:
+            return
+        url = f"{self._base_url}/{path.lstrip('/')}"
+        try:
+            with trace_time("server_db_request"):
+                response = self._session.post(
+                    url,
+                    json=dict(payload),
+                    timeout=self._timeout,
+                )
+            response.raise_for_status()
+        except Exception as exc:  # pragma: no cover - fire and forget
+            logger.warning("Server DB request to %s failed: %s", url, exc)
+
+
+def get_server_db() -> ServerDBClient | None:
+    if not SERVER_DB_ENABLED:
+        logger.info("Server DB integration disabled via configuration")
+        return None
+    if not SERVER_DB_BASE_URL:
+        logger.warning("SERVER_DB_BASE_URL is not configured; disabling server DB client")
+        return None
+    try:
+        client = ServerDBClient(
+            SERVER_DB_BASE_URL,
+            timeout=SERVER_DB_TIMEOUT,
+            token=SERVER_DB_AUTH_TOKEN,
+        )
+        return client
+    except Exception as exc:
+        logger.error("Failed to initialize Server DB client: %s", exc)
+        return None

--- a/user_app/services.py
+++ b/user_app/services.py
@@ -23,8 +23,8 @@ from telemetry import trace_time
 from user_app import db_local
 from user_app.api import UserAPI
 from user_app.db_local import LocalDB
-from user_app.signals import SessionSignals, SyncSignals
 from user_app.server_db import ServerDBClient, get_server_db
+from user_app.signals import SessionSignals, SyncSignals
 
 try:
     from sheets_api import SheetsAPI, get_sheets_api

--- a/user_app/services.py
+++ b/user_app/services.py
@@ -2,18 +2,29 @@ from __future__ import annotations
 
 import logging
 import threading
+import time
 from concurrent.futures import Future, ThreadPoolExecutor
-from typing import Callable
+from typing import Any, Callable, Mapping
 
 from PyQt5.QtCore import QThread
 
 from auto_sync import SyncManager
-from config import DB_FALLBACK_PATH, DB_MAIN_PATH, HEARTBEAT_PERIOD_SEC
+from config import (
+    DB_FALLBACK_PATH,
+    DB_MAIN_PATH,
+    HEARTBEAT_PERIOD_SEC,
+    WORKLOG_SORT_DEBOUNCE_SECONDS,
+    WORKLOG_SORT_LAST_HOURS,
+    WORKLOG_SORT_ON_APPEND,
+    WORKLOG_SORT_SCOPE,
+    WORKLOG_SORT_SECONDARY,
+)
 from telemetry import trace_time
 from user_app import db_local
 from user_app.api import UserAPI
 from user_app.db_local import LocalDB
 from user_app.signals import SessionSignals, SyncSignals
+from user_app.server_db import ServerDBClient, get_server_db
 
 try:
     from sheets_api import SheetsAPI, get_sheets_api
@@ -186,6 +197,52 @@ class AutoSyncService:
             logger.info("Auto-sync service stopped")
 
 
+class WorklogSortScheduler:
+    def __init__(self, services: "Services") -> None:
+        self._services = services
+        self._lock = threading.RLock()
+        self._last_run: dict[str, float] = {}
+
+    def schedule(self, group: str) -> None:
+        if not WORKLOG_SORT_ON_APPEND:
+            return
+
+        normalized = (group or "").strip() or "General"
+        debounce = max(1, WORKLOG_SORT_DEBOUNCE_SECONDS)
+        now = time.monotonic()
+        with self._lock:
+            last = self._last_run.get(normalized, 0.0)
+            if now - last < debounce:
+                logger.debug(
+                    "Worklog sort for %s skipped due to debounce (%.1fs)",
+                    normalized,
+                    debounce,
+                )
+                return
+            self._last_run[normalized] = now
+
+        def _run() -> None:
+            try:
+                sheets = self._services.sheets
+                sort_columns = ["Start"]
+                secondary = WORKLOG_SORT_SECONDARY
+                if secondary and secondary not in sort_columns:
+                    sort_columns.append(secondary)
+                sheets.sort_worklog(
+                    normalized,
+                    scope=WORKLOG_SORT_SCOPE,
+                    by=sort_columns,
+                    last_hours=WORKLOG_SORT_LAST_HOURS,
+                )
+            except Exception as exc:  # pragma: no cover - background logging only
+                logger.debug("Worklog sort for %s failed: %s", normalized, exc)
+            finally:
+                with self._lock:
+                    self._last_run[normalized] = time.monotonic()
+
+        self._services.submit(_run)
+
+
 class Services:
     def __init__(self) -> None:
         self._lock = threading.RLock()
@@ -197,6 +254,8 @@ class Services:
         self._auto_sync = AutoSyncService(self)
         self._session_signals: SessionSignals | None = None
         self._sync_signals: SyncSignals | None = None
+        self._server_db: ServerDBClient | None = None
+        self._worklog_sorter = WorklogSortScheduler(self)
 
     @property
     def db(self) -> LocalDB:
@@ -271,8 +330,15 @@ class Services:
         with self._lock:
             executor = self._executor
             self._executor = None
+            server_db = self._server_db
+            self._server_db = None
         if executor:
             executor.shutdown(wait=False)
+        if server_db:
+            try:
+                server_db.close()
+            except Exception:  # pragma: no cover - best effort cleanup
+                logger.debug("Server DB shutdown failed", exc_info=True)
         self.reset_db()
 
     def _ensure_db_initialized(self) -> None:
@@ -280,6 +346,53 @@ class Services:
             db_local.init_db(DB_MAIN_PATH, DB_FALLBACK_PATH)
         except Exception:
             logger.exception("Local DB initialization failed")
+
+    # --- Service helpers -----------------------------------------------------
+    def warmup_async(self) -> None:
+        def _warmup() -> None:
+            logger.debug("Services warmup task started")
+            try:
+                _ = self.sheets
+            except Exception as exc:  # pragma: no cover - network issues logged
+                logger.debug("Sheets warmup failed: %s", exc)
+            try:
+                _ = self.db
+            except Exception as exc:  # pragma: no cover
+                logger.debug("DB warmup failed: %s", exc)
+            server = self.server_db
+            if server:
+                server.ping()
+
+        self.submit(_warmup)
+
+    @property
+    def server_db(self) -> ServerDBClient | None:
+        with self._lock:
+            if self._server_db is None:
+                self._server_db = get_server_db()
+            return self._server_db
+
+    def replicate_session_start(self, payload: Mapping[str, Any]) -> None:
+        server = self.server_db
+        if not server:
+            return
+        self.submit(server.record_session_start, dict(payload))
+
+    def replicate_session_finish(self, payload: Mapping[str, Any]) -> None:
+        server = self.server_db
+        if not server:
+            return
+        self.submit(server.record_session_finish, dict(payload))
+
+    def replicate_action(self, payload: Mapping[str, Any]) -> None:
+        server = self.server_db
+        if not server:
+            return
+        self.submit(server.record_action, dict(payload))
+
+    def schedule_worklog_sort(self, group: str | None) -> None:
+        if self._worklog_sorter:
+            self._worklog_sorter.schedule(group or "")
 
 
 services = Services()

--- a/user_app/signals.py
+++ b/user_app/signals.py
@@ -20,3 +20,4 @@ class SessionSignals(QObject):
 
     # Причина завершения передаётся строкой (local_logout, remote_force_logout, ...)
     sessionFinished = pyqtSignal(str)
+    sessionFinalized = pyqtSignal(str)


### PR DESCRIPTION
## Summary
- add a reusable server database client and wire replication from the user app services for session/activity events
- warm up heavy services on startup, provide slow-login feedback, and return to the login window immediately on logout while background work continues
- add configurable WorkLog sorting via the Sheets API, schedule background sorts per group, and extend telemetry warnings for slow operations

## Testing
- ruff check .
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68cd5c9b5cd48327a8edf50a48e5570f